### PR TITLE
fix: remove all DKMS facer versions instead of hardcoded 0.2

### DIFF
--- a/scripts/remote-install.sh
+++ b/scripts/remote-install.sh
@@ -274,9 +274,13 @@ if make $MAKE_EXTRA > "$MAKE_LOG" 2>&1 && [ -f "$KERNEL_DIR/facer.ko" ]; then
     # "facer" module name ambiguously on boot, which can leave a stale
     # module loaded (breaking things like the WMI hotkey input device).
     if command -v dkms &>/dev/null && dkms status facer 2>/dev/null | grep -q .; then
-        dkms remove -m facer -v 0.2 --all 2>/dev/null || true
-        rm -rf /usr/src/facer-0.2 2>/dev/null || true
+        # Remove ALL versions of facer from DKMS (not just a hardcoded version)
+        for ver in $(dkms status facer 2>/dev/null | sed -n 's|^facer/\\([^,]*\\),.*|\\1|p'); do
+            dkms remove -m facer -v "$ver" --all 2>/dev/null || true
+            rm -rf "/usr/src/facer-$ver" 2>/dev/null || true
+        done
     fi
+
 
     # Make module load on every boot
     mkdir -p "/lib/modules/$(uname -r)/extra/"

--- a/scripts/remote-install.sh
+++ b/scripts/remote-install.sh
@@ -275,12 +275,11 @@ if make $MAKE_EXTRA > "$MAKE_LOG" 2>&1 && [ -f "$KERNEL_DIR/facer.ko" ]; then
     # module loaded (breaking things like the WMI hotkey input device).
     if command -v dkms &>/dev/null && dkms status facer 2>/dev/null | grep -q .; then
         # Remove ALL versions of facer from DKMS (not just a hardcoded version)
-        for ver in $(dkms status facer 2>/dev/null | sed -n 's|^facer/\\([^,]*\\),.*|\\1|p'); do
+        for ver in $(dkms status facer 2>/dev/null | sed -n 's|^facer/\([^,]*\),.*|\1|p'); do
             dkms remove -m facer -v "$ver" --all 2>/dev/null || true
             rm -rf "/usr/src/facer-$ver" 2>/dev/null || true
         done
     fi
-
 
     # Make module load on every boot
     mkdir -p "/lib/modules/$(uname -r)/extra/"


### PR DESCRIPTION
## Problem

`remote-install.sh` line 277 hardcodes `dkms remove -m facer -v 0.2`, but users who previously installed via DKMS with a different version (e.g., `1.0` from an older `dkms.conf` or manual setup) are left with a stale DKMS-managed module that never gets cleaned up.

This causes `dkms status` to show:

```
facer/1.0, 7.0.13-200.fc44.x86_64, x86_64: installed (Differences between built and installed modules)
```

On next boot, `depmod/modprobe` resolves ambiguously between the DKMS copy and the `insmod` copy, potentially loading the stale one — which breaks the WMI hotkey input device (keycode 425 stops being emitted entirely).

## Fix

Replace the hardcoded version removal with a loop that detects and removes ALL registered DKMS versions of facer:

```bash
for ver in $(dkms status facer 2>/dev/null | sed -n 's|^facer/\\([^,]*\\),.*|\\1|p'); do
    dkms remove -m facer -v "$ver" --all 2>/dev/null || true
    rm -rf "/usr/src/facer-$ver" 2>/dev/null || true
done
```

## Testing

- Tested on Fedora 44, kernel 7.0.13-200.fc44.x86_64, PHN16-73
- Had `facer/1.0` registered in DKMS from a previous install
- Confirmed the regex correctly extracts version from `dkms status` output for both `0.2` and `1.0`
- After manual application of this fix + reboot, module ambiguity resolved

## Related

Issue #4 — this was identified as the root cause of the hotkey regression (WMI hotkey device stops emitting events when the wrong module is loaded on boot).