### PR TITLE
fix(installers): tecla PredatorSense nunca funcionava — enable do serviço de hotkey falhava silencioso nos 3 instaladores

### DIFF
--- a/predator-sense-gui/installer/main.go
+++ b/predator-sense-gui/installer/main.go
@@ -802,7 +802,13 @@ RestartSec=5
 WantedBy=default.target`
 	svcPath := filepath.Join(svcDir, "predator-sense-hotkey.service")
 	os.WriteFile(svcPath, []byte(service), 0644)
-	chownToUser(svcPath)
+	// MkdirAll above runs as root: on a fresh ~/.config/systemd tree the
+	// directories end up root-owned, and systemd --user (which runs as the
+	// user) can't create the enable symlink in default.target.wants/ —
+	// enable fails forever, even when run manually later. Chown the whole
+	// tree, not just the unit file; this also repairs installs left broken
+	// by older versions.
+	run("chown", "-R", realUser+":"+realUser, filepath.Join(realHome, ".config/systemd"))
 
 	// Remove legacy XDG autostart entry — older installs wrote both this and the
 	// systemd unit, which spawned two listeners that each dispatched Activate on
@@ -1311,6 +1317,3 @@ func copyDir(src, dst string) error {
 	return nil
 }
 
-func chownToUser(path string) {
-	run("chown", realUser+":"+realUser, path)
-}

--- a/predator-sense-gui/setup.sh
+++ b/predator-sense-gui/setup.sh
@@ -412,7 +412,13 @@ RestartSec=5
 [Install]
 WantedBy=default.target
 EOF
-    chown -R "$REAL_USER:$REAL_USER" "$svc_dir/predator-sense-hotkey.service"
+    # mkdir -p above runs as root: on a fresh ~/.config/systemd tree the
+    # directories end up root-owned, and systemd --user (which runs as the
+    # user) can't create the enable symlink in default.target.wants/ — enable
+    # fails forever, even when run manually later. Chown the whole tree, not
+    # just the unit file; this also repairs installs left broken by older
+    # versions.
+    chown -R "$REAL_USER:$REAL_USER" "$REAL_HOME/.config/systemd"
 
     # Remove legacy XDG autostart entry from older installs.
     rm -f "$REAL_HOME/.config/autostart/predator-sense-hotkey.desktop"
@@ -421,7 +427,18 @@ EOF
     # duplicate listeners surviving across reinstalls).
     pkill -f "/opt/predator-sense/hotkey-daemon.py" 2>/dev/null || true
 
-    sudo -u "$REAL_USER" bash -c 'systemctl --user daemon-reload && systemctl --user enable --now predator-sense-hotkey.service' 2>/dev/null || true
+    # systemctl --user talks to the user's session bus, but under `sudo -u`
+    # neither XDG_RUNTIME_DIR nor DBUS_SESSION_BUS_ADDRESS is set, so this
+    # call always failed silently. Inject the same env the Go installer
+    # already builds in runAsUser(), and surface the failure.
+    local real_uid
+    real_uid=$(id -u "$REAL_USER")
+    if ! sudo -u "$REAL_USER" env \
+        XDG_RUNTIME_DIR="/run/user/$real_uid" \
+        DBUS_SESSION_BUS_ADDRESS="unix:path=/run/user/$real_uid/bus" \
+        bash -c 'systemctl --user daemon-reload && systemctl --user enable --now predator-sense-hotkey.service' 2>/dev/null; then
+        echo -e "${RED}Hotkey service not enabled${NC} — log in as $REAL_USER and run: systemctl --user enable --now predator-sense-hotkey.service"
+    fi
 
     # System-level (root) boot service: re-applies persisted battery-limit
     # settings on every boot (issue #11). Needs root, so it's separate from
@@ -535,7 +552,15 @@ do_uninstall() {
     pkill -f "tray_helper" 2>/dev/null || true
     sleep 1
 
-    sudo -u "$REAL_USER" bash -c '
+    # Same session-bus env needed here as in install_hotkey() — without it
+    # stop/disable never reached the user's systemd and the unit stayed
+    # enabled (dangling symlink) after uninstall.
+    local real_uid
+    real_uid=$(id -u "$REAL_USER")
+    sudo -u "$REAL_USER" env \
+        XDG_RUNTIME_DIR="/run/user/$real_uid" \
+        DBUS_SESSION_BUS_ADDRESS="unix:path=/run/user/$real_uid/bus" \
+        bash -c '
     systemctl --user stop predator-sense-hotkey.service 2>/dev/null
     systemctl --user disable predator-sense-hotkey.service 2>/dev/null
     rm -f ~/.config/systemd/user/predator-sense-hotkey.service

--- a/scripts/remote-install.sh
+++ b/scripts/remote-install.sh
@@ -558,7 +558,12 @@ RestartSec=5
 [Install]
 WantedBy=default.target
 SERVICE
-chown -R "$REAL_USER:$REAL_USER" "$SVC_DIR/predator-sense-hotkey.service"
+# mkdir -p above runs as root: on a fresh ~/.config/systemd tree the
+# directories end up root-owned, and systemd --user (which runs as the user)
+# can't create the enable symlink in default.target.wants/ — enable fails
+# forever, even when run manually later. Chown the whole tree, not just the
+# unit file; this also repairs installs left broken by older versions.
+chown -R "$REAL_USER:$REAL_USER" "$REAL_HOME/.config/systemd"
 
 # Remove legacy XDG autostart entry from older installs.
 rm -f "$REAL_HOME/.config/autostart/predator-sense-hotkey.desktop"
@@ -567,8 +572,20 @@ rm -f "$REAL_HOME/.config/autostart/predator-sense-hotkey.desktop"
 # listeners surviving across reinstalls).
 pkill -f "/opt/predator-sense/hotkey-daemon.py" 2>/dev/null || true
 
-sudo -u "$REAL_USER" bash -c 'systemctl --user daemon-reload && systemctl --user enable --now predator-sense-hotkey.service' 2>/dev/null || true
-msg ok "Hotkey + autostart configured"
+# systemctl --user talks to the user's session bus, but under `sudo -u`
+# neither XDG_RUNTIME_DIR nor DBUS_SESSION_BUS_ADDRESS is set, so this call
+# always failed — and `2>/dev/null || true` hid it while the installer still
+# printed success. Inject the same env the Go installer already builds in
+# runAsUser(), and surface the failure instead of swallowing it.
+REAL_UID=$(id -u "$REAL_USER")
+if sudo -u "$REAL_USER" env \
+    XDG_RUNTIME_DIR="/run/user/$REAL_UID" \
+    DBUS_SESSION_BUS_ADDRESS="unix:path=/run/user/$REAL_UID/bus" \
+    bash -c 'systemctl --user daemon-reload && systemctl --user enable --now predator-sense-hotkey.service' 2>/dev/null; then
+    msg ok "Hotkey + autostart configured"
+else
+    msg fail "Hotkey service not enabled — log in as $REAL_USER and run: systemctl --user enable --now predator-sense-hotkey.service"
+fi
 
 # System-level (root) boot service: re-applies persisted battery-limit
 # settings on every boot (issue #11). Needs root, so it's separate from the


### PR DESCRIPTION
## Problema

Em instalação nova a tecla PredatorSense não faz nada: o `predator-sense-hotkey.service` é criado, mas fica **disabled/inactive para sempre**, com o instalador ainda imprimindo `✓ Hotkey + autostart configured`. São dois bugs independentes, ambos silenciosos:

**1) `systemctl --user` sem sessão D-Bus** (`remote-install.sh` e `setup.sh`)

Os scripts rodam como root e chamam:

```bash
sudo -u "$REAL_USER" bash -c 'systemctl --user daemon-reload && systemctl --user enable --now predator-sense-hotkey.service' 2>/dev/null || true
```

Sob `sudo -u`, nem `XDG_RUNTIME_DIR` nem `DBUS_SESSION_BUS_ADDRESS` são definidos, então o `systemctl --user` nunca alcança o systemd da sessão do usuário:

```
Failed to connect to user scope bus via local transport: $DBUS_SESSION_BUS_ADDRESS and $XDG_RUNTIME_DIR not defined
```

O `2>/dev/null || true` engole o erro e o instalador reporta sucesso. O installer Go **não** tem esse bug — `runAsUser()` já injeta as duas variáveis. O `do_uninstall()` do setup.sh sofre do mesmo problema (stop/disable nunca chegam no systemd do usuário; o symlink de enable fica órfão após desinstalar).

**2) `~/.config/systemd` com posse de root** (os 3 instaladores)

O `mkdir -p`/`os.MkdirAll` roda como root e o chown cobre só o arquivo `.service`, não os diretórios criados junto. Com o diretório de root, o systemd --user (que roda como o usuário) não consegue criar o symlink de enable em `default.target.wants/` — aí nem o fix (1) nem um enable manual funcionam:

```
Failed to enable unit: Unit /home/user/.config/systemd/user/default.target.wants/predator-sense-hotkey.service does not exist
```

## Fix

- `remote-install.sh` e `setup.sh` (install + uninstall): injetam o mesmo env que o `runAsUser()` do Go já usa (`sudo -u ... env XDG_RUNTIME_DIR=/run/user/$uid DBUS_SESSION_BUS_ADDRESS=unix:path=/run/user/$uid/bus`), na mesma direção de 6ef1332 (fechar gaps entre os 3 instaladores).
- Enable que falha agora imprime aviso com o comando manual em vez de reportar sucesso falso.
- Os 3 instaladores: `chown -R` de `~/.config/systemd` inteiro (não só o unit file) — também **repara instalações antigas** que já ficaram com os diretórios de root.
- `chownToUser()` ficou sem uso no Go e foi removida.

## Testes

- Encontrado ao vivo num **PHN16-73 (V1.26), CachyOS, KDE Wayland**, instalado via `remote-install.sh`: serviço dead + `~/.config/systemd` de root confirmados; aplicando os dois passos do fix manualmente o serviço foi a active/enabled.
- Mecanismo reproduzido isolado: `env -i HOME=... systemctl --user is-active` falha sem as duas variáveis e responde `active` com elas.
- `bash -n` limpo nos dois scripts; `go build` + `go vet` limpos no installer.

## Relacionado

- Mesma classe de gap entre instaladores auditada em 6ef1332 — este cobre o caminho de enable do serviço de hotkey, que ficou de fora.
- Explica relatos de "tecla não faz nada" mesmo com módulo `facer` carregado e keycode 425 sendo emitido (o daemon simplesmente nunca estava rodando).
