### PR TITLE
fix(gui): app ocioso queimava ~84% de CPU renderizando sem parar (issue #13) + stalls de nvidia-smi na main thread

### DIFF
--- a/predator-sense-gui/resources/style.css
+++ b/predator-sense-gui/resources/style.css
@@ -650,17 +650,15 @@ scrollbar slider:hover {
 .stat-value { font-size: 20px; font-weight: 700; color: @text_main; }
 .stat-unit { font-size: 11px; color: @text_muted; margin-bottom: 4px; }
 
-/* === Pulsing green status dot === */
-@keyframes pulse-green {
-    0% { color: #3fb950; }
-    50% { color: #1a6b28; }
-    100% { color: #3fb950; }
-}
-
+/* === Pulsing green status dot ===
+   Pulsed by a 5 fps opacity timer in window.rs, NOT a CSS animation: an
+   `animation: ... infinite` on an always-mapped widget pins the GTK frame
+   clock at panel refresh rate, and every frame re-rasterizes the window's
+   cairo render nodes in software — measured at ~84% of a core with the app
+   idle on a 165 Hz panel (issue #13). */
 .status-dot-pulse {
     color: #3fb950;
     font-size: 10px;
-    animation: pulse-green 2s ease-in-out infinite;
 }
 
 /* === Dashboard === */

--- a/predator-sense-gui/src/hardware/gpu.rs
+++ b/predator-sense-gui/src/hardware/gpu.rs
@@ -1,4 +1,5 @@
 use std::process::Command;
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Mutex;
 use std::time::{Duration, Instant};
 
@@ -52,15 +53,37 @@ impl GpuMetrics {
 static CACHE: Mutex<Option<(Instant, GpuMetrics)>> = Mutex::new(None);
 const TTL: Duration = Duration::from_millis(1800);
 
+static REFRESHING: AtomicBool = AtomicBool::new(false);
+
 pub fn read_gpu_metrics() -> GpuMetrics {
     if let Some((t, m)) = CACHE.lock().unwrap().as_ref() {
         if t.elapsed() < TTL {
             return m.clone();
         }
     }
-    let m = fetch_gpu_metrics();
-    *CACHE.lock().unwrap() = Some((Instant::now(), m.clone()));
-    m
+    // Stale or empty: refresh OFF the main thread — same reasoning as
+    // sensors::read_nvidia_gpu_info(). nvidia-smi blocks for ~40 ms with the
+    // GPU awake and ~850 ms waking it from D3cold, and every caller here is
+    // a GTK timeout on the main loop. While the dGPU is runtime-suspended,
+    // skip the query entirely instead of powering it up just to read idle
+    // metrics.
+    if !REFRESHING.swap(true, Ordering::AcqRel) {
+        std::thread::spawn(|| {
+            let m = if crate::hardware::sensors::nvidia_suspended() {
+                GpuMetrics::default()
+            } else {
+                fetch_gpu_metrics()
+            };
+            *CACHE.lock().unwrap() = Some((Instant::now(), m));
+            REFRESHING.store(false, Ordering::Release);
+        });
+    }
+    CACHE
+        .lock()
+        .unwrap()
+        .as_ref()
+        .map(|(_, m)| m.clone())
+        .unwrap_or_default()
 }
 
 fn fetch_gpu_metrics() -> GpuMetrics {

--- a/predator-sense-gui/src/hardware/sensors.rs
+++ b/predator-sense-gui/src/hardware/sensors.rs
@@ -1,4 +1,5 @@
 use std::fs;
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Mutex;
 use std::time::{Duration, Instant};
 
@@ -42,6 +43,27 @@ static PREV_NET: Mutex<Option<(u64, u64, Instant)>> = Mutex::new(None);
 // sensors in parallel don't fork it dozens of times per second.
 static GPU_CACHE: Mutex<Option<(Instant, GpuInfo)>> = Mutex::new(None);
 const GPU_TTL: Duration = Duration::from_millis(1800);
+static GPU_REFRESHING: AtomicBool = AtomicBool::new(false);
+
+/// True when the NVIDIA dGPU is runtime-suspended (D3cold). Querying it via
+/// nvidia-smi would power the whole GPU back up (~850 ms measured on a
+/// PHN16-73) just to read the temperature of a chip that is turned off — so
+/// monitoring paths skip the query instead of waking it.
+pub(crate) fn nvidia_suspended() -> bool {
+    let Ok(entries) = fs::read_dir("/sys/bus/pci/devices") else { return false };
+    for e in entries.flatten() {
+        let p = e.path();
+        let is_nvidia = fs::read_to_string(p.join("vendor"))
+            .is_ok_and(|v| v.trim() == "0x10de");
+        let is_gpu = fs::read_to_string(p.join("class"))
+            .is_ok_and(|c| c.trim().starts_with("0x03"));
+        if is_nvidia && is_gpu {
+            return fs::read_to_string(p.join("power/runtime_status"))
+                .is_ok_and(|s| s.trim() == "suspended");
+        }
+    }
+    false
+}
 
 pub fn read_all_sensors() -> SensorData {
     let gpu_info = read_nvidia_gpu_info();
@@ -167,6 +189,28 @@ fn read_nvidia_gpu_info() -> GpuInfo {
             }
         }
     }
+    // Stale or empty: refresh OFF the main thread. nvidia-smi takes ~40 ms
+    // with the GPU awake and ~850 ms when it has to power it up from D3cold;
+    // every caller of this function is a GTK timeout on the main loop, so
+    // running it inline froze the UI for that long on every cache expiry.
+    // Return the stale value (or defaults on the very first call) right away
+    // and let the next tick pick up the refreshed one.
+    if !GPU_REFRESHING.swap(true, Ordering::AcqRel) {
+        std::thread::spawn(|| {
+            let info = if nvidia_suspended() { GpuInfo::default() } else { fetch_nvidia_gpu_info() };
+            *GPU_CACHE.lock().unwrap() = Some((Instant::now(), info));
+            GPU_REFRESHING.store(false, Ordering::Release);
+        });
+    }
+    GPU_CACHE
+        .lock()
+        .unwrap()
+        .as_ref()
+        .map(|(_, info)| info.clone())
+        .unwrap_or_default()
+}
+
+fn fetch_nvidia_gpu_info() -> GpuInfo {
     let o = std::process::Command::new("nvidia-smi")
         .args(["--query-gpu=name,temperature.gpu,fan.speed,clocks.gr,clocks.mem,utilization.gpu,power.draw",
                "--format=csv,noheader,nounits"]).output();
@@ -190,7 +234,6 @@ fn read_nvidia_gpu_info() -> GpuInfo {
         }
         _ => GpuInfo::default(),
     };
-    *GPU_CACHE.lock().unwrap() = Some((Instant::now(), info.clone()));
     info
 }
 

--- a/predator-sense-gui/src/main.rs
+++ b/predator-sense-gui/src/main.rs
@@ -29,6 +29,17 @@ pub fn apply_font_scale(scale: f64) {
 }
 
 fn main() {
+    // GTK 4.16+ picks the Vulkan renderer by default. Creating the Vulkan
+    // instance enumerates every GPU in the system, which opens /dev/nvidia*
+    // and keeps a hybrid laptop's discrete GPU powered — blocked from
+    // runtime-suspending into D3cold — for the app's whole lifetime, plus
+    // visibly janky frame pacing on NVIDIA PRIME setups. The GL renderer
+    // only touches the GPU that actually drives the display. An explicit
+    // user override still wins.
+    if std::env::var_os("GSK_RENDERER").is_none() {
+        std::env::set_var("GSK_RENDERER", "ngl");
+    }
+
     let app = adw::Application::builder()
         .application_id(APP_ID)
         .build();

--- a/predator-sense-gui/src/ui/battery_page.rs
+++ b/predator-sense-gui/src/ui/battery_page.rs
@@ -280,7 +280,7 @@ pub fn build() -> gtk::Box {
 
     let page_c = page.clone();
     glib::timeout_add_seconds_local(2, move || {
-        if !crate::app_state::is_window_visible() || !page_c.is_visible() {
+        if !crate::app_state::is_window_visible() || !page_c.is_mapped() {
             return glib::ControlFlow::Continue;
         }
         update(&all, &bp, &bc, &hist);

--- a/predator-sense-gui/src/ui/fan_control_page.rs
+++ b/predator-sense-gui/src/ui/fan_control_page.rs
@@ -373,7 +373,7 @@ pub fn build() -> gtk::Box {
 
     let page_anim = page.clone();
     glib::timeout_add_local(std::time::Duration::from_millis(60), move || {
-        if !crate::app_state::is_window_visible() || !page_anim.is_visible() {
+        if !crate::app_state::is_window_visible() || !page_anim.is_mapped() {
             return glib::ControlFlow::Continue;
         }
         let cpu_r = *cr1.borrow();
@@ -397,7 +397,7 @@ pub fn build() -> gtk::Box {
     let gt2 = gpu_temp.clone();
     let page_sense = page.clone();
     glib::timeout_add_seconds_local(2, move || {
-        if !crate::app_state::is_window_visible() || !page_sense.is_visible() {
+        if !crate::app_state::is_window_visible() || !page_sense.is_mapped() {
             return glib::ControlFlow::Continue;
         }
         let data = sensors::read_all_sensors();

--- a/predator-sense-gui/src/ui/gpu_page.rs
+++ b/predator-sense-gui/src/ui/gpu_page.rs
@@ -216,7 +216,7 @@ pub fn build() -> gtk::Box {
     let w = all_widgets;
     let page_c = page.clone();
     glib::timeout_add_seconds_local(2, move || {
-        if !crate::app_state::is_window_visible() || !page_c.is_visible() {
+        if !crate::app_state::is_window_visible() || !page_c.is_mapped() {
             return glib::ControlFlow::Continue;
         }
         update(&s, &w);

--- a/predator-sense-gui/src/ui/monitor_page.rs
+++ b/predator-sense-gui/src/ui/monitor_page.rs
@@ -210,7 +210,7 @@ pub fn build() -> gtk::Box {
 
     let page_c = page.clone();
     glib::timeout_add_seconds_local(2, move || {
-        if !crate::app_state::is_window_visible() || !page_c.is_visible() {
+        if !crate::app_state::is_window_visible() || !page_c.is_mapped() {
             return glib::ControlFlow::Continue;
         }
         do_update(

--- a/predator-sense-gui/src/ui/network_page.rs
+++ b/predator-sense-gui/src/ui/network_page.rs
@@ -194,7 +194,7 @@ pub fn build() -> gtk::Box {
 
         let page_c = page.clone();
         glib::timeout_add_seconds_local(2, move || {
-            if !crate::app_state::is_window_visible() || !page_c.is_visible() {
+            if !crate::app_state::is_window_visible() || !page_c.is_mapped() {
                 return glib::ControlFlow::Continue;
             }
             update_net_stats(
@@ -211,7 +211,7 @@ pub fn build() -> gtk::Box {
         let ul_da = ul_anim_da.clone();
         let page_c = page.clone();
         glib::timeout_add_local(std::time::Duration::from_millis(60), move || {
-            if !crate::app_state::is_window_visible() || !page_c.is_visible() {
+            if !crate::app_state::is_window_visible() || !page_c.is_mapped() {
                 return glib::ControlFlow::Continue;
             }
             {

--- a/predator-sense-gui/src/ui/usage_page.rs
+++ b/predator-sense-gui/src/ui/usage_page.rs
@@ -139,7 +139,7 @@ pub fn build() -> gtk::Box {
         let sampler_c = sampler.clone();
         let page_c = page.clone();
         glib::timeout_add_seconds_local(2, move || {
-            if !crate::app_state::is_window_visible() || !page_c.is_visible() {
+            if !crate::app_state::is_window_visible() || !page_c.is_mapped() {
                 return glib::ControlFlow::Continue;
             }
             let mut s = sampler_c.borrow_mut();
@@ -162,7 +162,7 @@ pub fn build() -> gtk::Box {
         let state_c = state.clone();
         let page_c = page.clone();
         glib::timeout_add_local(std::time::Duration::from_millis(60), move || {
-            if !crate::app_state::is_window_visible() || !page_c.is_visible() {
+            if !crate::app_state::is_window_visible() || !page_c.is_mapped() {
                 return glib::ControlFlow::Continue;
             }
             let mut st = state_c.borrow_mut();
@@ -328,7 +328,7 @@ fn build_cpu_tab(state: Rc<RefCell<AnimState>>) -> gtk::Box {
     let lc_anim = list_container.clone();
     let page_anim = page.clone();
     glib::timeout_add_local(std::time::Duration::from_millis(60), move || {
-        if !crate::app_state::is_window_visible() || !page_anim.is_visible() {
+        if !crate::app_state::is_window_visible() || !page_anim.is_mapped() {
             return glib::ControlFlow::Continue;
         }
         gauge_da_c.queue_draw();
@@ -345,7 +345,7 @@ fn build_cpu_tab(state: Rc<RefCell<AnimState>>) -> gtk::Box {
 
     let page_list = page.clone();
     glib::timeout_add_seconds_local(2, move || {
-        if !crate::app_state::is_window_visible() || !page_list.is_visible() {
+        if !crate::app_state::is_window_visible() || !page_list.is_mapped() {
             return glib::ControlFlow::Continue;
         }
         rebuild_cpu_process_list(&lc, &state_list);
@@ -513,7 +513,7 @@ fn build_gpu_tab(state: Rc<RefCell<AnimState>>) -> gtk::Box {
     let power_da_c = power_da.clone();
     let page_c = page.clone();
     glib::timeout_add_local(std::time::Duration::from_millis(60), move || {
-        if !crate::app_state::is_window_visible() || !page_c.is_visible() {
+        if !crate::app_state::is_window_visible() || !page_c.is_mapped() {
             return glib::ControlFlow::Continue;
         }
         let st = st_u.borrow();
@@ -612,7 +612,7 @@ fn build_mem_tab(state: Rc<RefCell<AnimState>>) -> gtk::Box {
     let list_anim = list.clone();
     let page_anim = page.clone();
     glib::timeout_add_local(std::time::Duration::from_millis(60), move || {
-        if !crate::app_state::is_window_visible() || !page_anim.is_visible() {
+        if !crate::app_state::is_window_visible() || !page_anim.is_mapped() {
             return glib::ControlFlow::Continue;
         }
         let st = st_u.borrow();
@@ -644,7 +644,7 @@ fn build_mem_tab(state: Rc<RefCell<AnimState>>) -> gtk::Box {
     let lc = list.clone();
     let page_list = page.clone();
     glib::timeout_add_seconds_local(2, move || {
-        if !crate::app_state::is_window_visible() || !page_list.is_visible() {
+        if !crate::app_state::is_window_visible() || !page_list.is_mapped() {
             return glib::ControlFlow::Continue;
         }
         rebuild_mem_process_list(&lc, &st_list);
@@ -723,7 +723,7 @@ fn build_storage_tab(state: Rc<RefCell<AnimState>>) -> gtk::Box {
     let flow_c = flow.clone();
     let outer_list = outer.clone();
     glib::timeout_add_seconds_local(3, move || {
-        if !crate::app_state::is_window_visible() || !outer_list.is_visible() {
+        if !crate::app_state::is_window_visible() || !outer_list.is_mapped() {
             return glib::ControlFlow::Continue;
         }
         rebuild_storage_cards(&flow_c, &st_list);
@@ -739,7 +739,7 @@ fn build_storage_tab(state: Rc<RefCell<AnimState>>) -> gtk::Box {
     let flow_c2 = flow.clone();
     let outer_anim = outer.clone();
     glib::timeout_add_local(std::time::Duration::from_millis(60), move || {
-        if !crate::app_state::is_window_visible() || !outer_anim.is_visible() {
+        if !crate::app_state::is_window_visible() || !outer_anim.is_mapped() {
             return glib::ControlFlow::Continue;
         }
         // Percorre filhos e força redraw no DrawingArea

--- a/predator-sense-gui/src/ui/window.rs
+++ b/predator-sense-gui/src/ui/window.rs
@@ -241,26 +241,32 @@ fn build_main_ui(app: &adw::Application, window: &gtk::ApplicationWindow) {
     let root_overlay = gtk::Overlay::new();
     root_overlay.set_child(Some(&main_content));
 
-    let neon_bars = gtk::DrawingArea::new();
-    neon_bars.set_hexpand(true);
-    neon_bars.set_vexpand(true);
-    neon_bars.set_can_target(false);
-
-    // Pulse animation: phase cycles 0.0 -> 1.0 continuously
+    // Two slim edge-hugging DrawingAreas instead of one full-window overlay:
+    // the pulse timer below re-rasterizes whatever surface it invalidates,
+    // and at full-window size that meant a window-sized cairo software pass
+    // 5x/second forever — one of the issue #13 idle-CPU culprits. 32 px
+    // covers the 4 px core bar plus the widest glow layer (10 px outward,
+    // clipped by the window edge exactly like before, and 14 px inward), so
+    // the result is pixel-identical to the old full-window draw.
     let pulse_phase: Rc<RefCell<f64>> = Rc::new(RefCell::new(0.0));
-
-    {
+    let mut neon_bars = Vec::new();
+    for left in [true, false] {
+        let bar = gtk::DrawingArea::new();
+        bar.set_content_width(32);
+        bar.set_vexpand(true);
+        bar.set_halign(if left { gtk::Align::Start } else { gtk::Align::End });
+        bar.set_can_target(false);
         let phase = pulse_phase.clone();
-        neon_bars.set_draw_func(move |_a, cr, w, h| {
-            let p = *phase.borrow();
-            draw_neon_edges(cr, w as f64, h as f64, p);
+        bar.set_draw_func(move |_a, cr, w, h| {
+            draw_neon_bar(cr, w as f64, h as f64, *phase.borrow(), left);
         });
+        root_overlay.add_overlay(&bar);
+        neon_bars.push(bar);
     }
 
     // Animate at ~5fps. The neon edge is a slow background pulse — full 60fps
     // here was visually identical but burned ~30% CPU drawing layered Cairo
     // strokes on every redraw cycle of the entire window.
-    let neon_c = neon_bars.clone();
     let phase_c = pulse_phase.clone();
     glib::timeout_add_local(std::time::Duration::from_millis(200), move || {
         if !crate::app_state::is_window_visible() {
@@ -270,11 +276,11 @@ fn build_main_ui(app: &adw::Application, window: &gtk::ApplicationWindow) {
         *p += 0.12;
         if *p > 1.0 { *p -= 1.0; }
         drop(p);
-        neon_c.queue_draw();
+        for bar in &neon_bars {
+            bar.queue_draw();
+        }
         glib::ControlFlow::Continue
     });
-
-    root_overlay.add_overlay(&neon_bars);
 
     window.set_child(Some(&root_overlay));
 }
@@ -376,6 +382,8 @@ fn build_main_content(app: &adw::Application, window: &gtk::ApplicationWindow) -
     let active_idx: Rc<RefCell<usize>> = Rc::new(RefCell::new(0));
     let nav_widgets: Rc<RefCell<Vec<(gtk::DrawingArea, gtk::Label)>>> =
         Rc::new(RefCell::new(Vec::new()));
+    // Captured by the shared sidebar pulse timer created after the loop.
+    let beta_badge: Rc<RefCell<Option<gtk::Label>>> = Rc::new(RefCell::new(None));
 
     for (i, (label, page_name)) in nav_items.iter().enumerate() {
         let item_overlay = gtk::Overlay::new();
@@ -416,21 +424,10 @@ fn build_main_content(app: &adw::Application, window: &gtk::ApplicationWindow) -
             badge.set_margin_top(4);
             item_overlay.add_overlay(&badge);
 
-            let badge_c = badge.clone();
-            let phase: Rc<RefCell<f64>> = Rc::new(RefCell::new(0.0));
-            glib::timeout_add_local(std::time::Duration::from_millis(60), move || {
-                if !crate::app_state::is_window_visible() {
-                    return glib::ControlFlow::Continue;
-                }
-                let mut p = phase.borrow_mut();
-                *p += 0.04;
-                if *p > std::f64::consts::TAU {
-                    *p -= std::f64::consts::TAU;
-                }
-                let opacity = 0.55 + 0.45 * ((p.sin() + 1.0) / 2.0);
-                badge_c.set_opacity(opacity);
-                glib::ControlFlow::Continue
-            });
+            // Pulsed by the shared 5 fps sidebar timer below (was a dedicated
+            // 16 fps timer — see that timer's comment for why the rate
+            // matters).
+            *beta_badge.borrow_mut() = Some(badge.clone());
         }
 
         // Click
@@ -489,12 +486,48 @@ fn build_main_content(app: &adw::Application, window: &gtk::ApplicationWindow) -
     ver.set_halign(gtk::Align::Center);
     info_box.append(&ver);
 
-    // Status dot (pulsing via CSS animation - green)
+    // Status dot (pulsing green)
     let status_row = gtk::Box::new(gtk::Orientation::Horizontal, 6);
     status_row.set_halign(gtk::Align::Center);
     status_row.set_margin_top(4);
     let dot = gtk::Label::new(Some("●"));
     dot.add_css_class(if rgb::is_module_loaded() { "status-dot-pulse" } else { "status-dot-off" });
+
+    // One shared 5 fps timer pulses both sidebar accents (status dot + BETA
+    // badge) via opacity. This replaces a CSS `animation: infinite` on the
+    // dot and a dedicated 16 fps set_opacity() timer on the badge: an
+    // infinite CSS animation on an always-mapped widget pins the GTK frame
+    // clock at panel refresh rate, re-rasterizing the window's cairo nodes
+    // in software nonstop — measured at ~84% of a core with the app idle on
+    // a 165 Hz panel (issue #13). A discrete 5 fps sine is visually
+    // equivalent for pulses this slow and lets the frame clock go fully
+    // idle between ticks.
+    {
+        let dot_pulses = rgb::is_module_loaded();
+        let dot_c = dot.clone();
+        let badge_c = beta_badge.clone();
+        let phase: Rc<RefCell<f64>> = Rc::new(RefCell::new(0.0));
+        glib::timeout_add_local(std::time::Duration::from_millis(200), move || {
+            if !crate::app_state::is_window_visible() {
+                return glib::ControlFlow::Continue;
+            }
+            let mut p = phase.borrow_mut();
+            *p += 0.1;
+            if *p > 1.0 {
+                *p -= 1.0;
+            }
+            let wave = ((*p * 2.0 * PI).sin() + 1.0) / 2.0;
+            drop(p);
+            if dot_pulses {
+                // Same 2 s bright↔dim cycle the CSS keyframes had.
+                dot_c.set_opacity(0.45 + 0.55 * wave);
+            }
+            if let Some(badge) = badge_c.borrow().as_ref() {
+                badge.set_opacity(0.55 + 0.45 * wave);
+            }
+            glib::ControlFlow::Continue
+        });
+    }
     let st = gtk::Label::new(Some(crate::i18n::t(if rgb::is_module_loaded() { "module_active" } else { "module_inactive" })));
     st.add_css_class("info-text-dim");
     status_row.append(&dot);
@@ -591,7 +624,10 @@ fn find_resource_path(name: &str) -> Option<std::path::PathBuf> {
 
 /// Draw pulsing cyan neon glow bars on left and right edges
 /// phase: 0.0 to 1.0, controls the pulse intensity
-fn draw_neon_edges(cr: &gtk4::cairo::Context, w: f64, h: f64, phase: f64) {
+/// Draw one neon edge bar (left or right) inside its own slim DrawingArea.
+/// Geometry matches the old full-window draw_neon_edges() exactly, just
+/// expressed in the slim area's local coordinates.
+fn draw_neon_bar(cr: &gtk4::cairo::Context, w: f64, h: f64, phase: f64, left: bool) {
     // Smooth sine pulse: oscillates between 0.4 and 1.0
     let pulse = 0.4 + 0.6 * ((phase * 2.0 * PI).sin() * 0.5 + 0.5);
 
@@ -600,44 +636,28 @@ fn draw_neon_edges(cr: &gtk4::cairo::Context, w: f64, h: f64, phase: f64) {
     let bottom = h * 0.90;
     let bar_h = bottom - top;
     let radius = 5.0;
+    let x0 = if left { 0.0 } else { w - bar_width };
 
-    // --- Left neon bar ---
     // Glow layers (pulsing)
     for i in 0..5 {
         let spread = (i as f64 + 1.0) * 4.0;
         let alpha = (0.15 / (i as f64 + 1.0)) * pulse;
         cr.set_source_rgba(0.0, 0.8, 0.9, alpha);
-        rounded_rect(cr, -spread / 2.0, top - spread / 2.0,
+        rounded_rect(cr, x0 - spread / 2.0, top - spread / 2.0,
                      bar_width + spread, bar_h + spread, radius + spread / 2.0);
         let _ = cr.fill();
     }
     // Core bar
     cr.set_source_rgba(0.0, 0.8, 0.9, 0.5 + 0.4 * pulse);
-    rounded_rect(cr, 0.0, top, bar_width, bar_h, radius);
-    let _ = cr.fill();
-
-    // --- Right neon bar ---
-    let rx = w - bar_width;
-    for i in 0..5 {
-        let spread = (i as f64 + 1.0) * 4.0;
-        let alpha = (0.15 / (i as f64 + 1.0)) * pulse;
-        cr.set_source_rgba(0.0, 0.8, 0.9, alpha);
-        rounded_rect(cr, rx - spread / 2.0, top - spread / 2.0,
-                     bar_width + spread, bar_h + spread, radius + spread / 2.0);
-        let _ = cr.fill();
-    }
-    cr.set_source_rgba(0.0, 0.8, 0.9, 0.5 + 0.4 * pulse);
-    rounded_rect(cr, rx, top, bar_width, bar_h, radius);
+    rounded_rect(cr, x0, top, bar_width, bar_h, radius);
     let _ = cr.fill();
 
     // Subtle edge border (also pulses slightly)
+    let ex = if left { 1.0 } else { w - 1.0 };
     cr.set_source_rgba(0.0, 0.8, 0.9, 0.15 + 0.2 * pulse);
     cr.set_line_width(2.0);
-    cr.move_to(1.0, 0.0);
-    cr.line_to(1.0, h);
-    let _ = cr.stroke();
-    cr.move_to(w - 1.0, 0.0);
-    cr.line_to(w - 1.0, h);
+    cr.move_to(ex, 0.0);
+    cr.line_to(ex, h);
     let _ = cr.stroke();
 }
 


### PR DESCRIPTION
## Problema

Reproduzi o issue #13 num **PHN16-73 (CachyOS, KDE Wayland, painel 165 Hz)**: o app parado no dashboard, sem nenhuma interação, consumia **83,6% de um core** (o issue reporta ~89% e um desligamento térmico). `perf` mostrou ~90% do tempo dentro de `libcairo`/`pixman` via `gsk_renderer_render` — nós cairo do scene graph re-rasterizados em software a cada frame.

Três animações perpétuas em widgets sempre mapeados forçavam frames contínuos:

1. **`animation: pulse-green ... infinite` (CSS)** no dot verde da sidebar — uma animação CSS infinita agenda frame em todo vsync (165 fps aqui). No teste A/B, desligar só essa linha derrubou o idle de 83,6% para ~0%.
2. **Badge "BETA"** pulsando via `set_opacity()` em timer de 60 ms — `GSK_DEBUG=fallback` registrou ~42 re-renders offscreen/s.
3. **Barras neon**: `queue_draw` a cada 200 ms numa DrawingArea de **janela inteira** — re-rasterização cairo de uma superfície do tamanho da janela, 5x/s, para sempre.

Mais dois problemas de responsividade encontrados na investigação:

4. **`nvidia-smi` síncrono na main thread** (todo caller é `glib::timeout`): ~40 ms com a GPU acordada e **~850 ms medidos quando ela sai de D3cold** — congela a UI ao entrar nas páginas de GPU/monitor. E como o watcher de alertas roda a cada 5 s (inclusive no tray), a dGPU de um híbrido **nunca conseguia suspender** — o app acordava a GPU inteira para ler a temperatura de um chip desligado.
5. **Guards `is_visible()`** nas páginas: no GTK4 isso lê a *propriedade* `visible` (true para filhos não-ativos de um `Stack`), então os pollers/animações de todas as páginas rodavam o tempo todo, em qualquer aba.
6. **Renderer Vulkan (default do GTK 4.16+)**: criar a instância Vulkan enumera todas as GPUs e abre `/dev/nvidia*`, segurando a dGPU acordada pela vida inteira do app (confirmado: 7 fds em `/dev/nvidia0` com vulkan; zero com GL) + frame pacing ruim em PRIME.

## Fix

Nenhum efeito visual foi removido — só o custo mudou:

- Dot + badge pulsam por **um timer compartilhado de 5 fps** via opacity (mesmos ciclos de antes; seno discreto a 5 fps é visualmente equivalente para pulsos lentos).
- Barras neon viraram **duas DrawingAreas finas de 32 px** nas bordas, mesmo pulso de 5 fps. 32 px cobre a barra de 4 px + o glow mais largo (10 px para fora, clipado pela borda da janela como antes, 14 px para dentro) — **pixel-idêntico**, superfície ~1% do tamanho.
- `sensors::read_nvidia_gpu_info()` e `gpu::read_gpu_metrics()`: cache existente em modo **stale-while-revalidate** — devolve o valor anterior na hora e renova em thread de fundo; com a dGPU runtime-suspended, a renovação nem invoca `nvidia-smi`. Detecção por vendor/class no sysfs PCI (agnóstica de distro); em máquinas sem NVIDIA nada muda.
- `is_visible()` → `is_mapped()` nos 16 guards.
- `GSK_RENDERER=ngl` como default **apenas quando a env não está definida** — override do usuário continua valendo; em single-GPU (Intel/AMD/NVIDIA) o GL renderer é igualmente suportado.

## Testes

- **83,6% → 2,7% de CPU idle** com todos os pulsos ativos; **0 frames** quando nada muda (`GDK_DEBUG=frames`: 5,0 fps em repouso, só dos pulsos).
- `nvidia-smi` medido isolado: 0,88 s acordando de D3cold, 0,04 s acordada — agora fora da main thread.
- Com o app aberto: zero fds NVIDIA (antes: 7 em `/dev/nvidia0` + nvidiactl + nvidia-modeset).
- Fluidez confirmada em uso real no PHN16-73 (KDE Wayland 165 Hz).
- `cargo build` sem warnings novos; suíte completa **31/31** após cada etapa.

## Relacionado

- Fecha o issue #13 (root cause do loop de render + a parte de "polling sem throttle" via is_mapped/stale-while-revalidate).
- Complementa o PR #14 (instaladores) — mesma sessão de investigação no PHN16-73.
