### PR TITLE
installer: match the DKMS package name for Linuwu-Sense

### DIFF
--- a/predator-sense-gui/installer/main.go
+++ b/predator-sense-gui/installer/main.go
@@ -337,12 +337,14 @@ func isModuleLoaded() bool { return runSilent("lsmod") && grepOutput("lsmod", "^
 
 // linuwuSensePresent reports whether the linuwu_sense kernel module (which
 // DAMX relies on for fan/thermal control) is already loaded or DKMS-installed.
-// It binds the same WMI GUIDs as facer, so the two cannot coexist.
+// It binds the same WMI GUIDs as facer, so the two cannot coexist. DKMS
+// registers the package as linuwu-sense while the module it builds is
+// linuwu_sense, so the two names have to be matched separately.
 func linuwuSensePresent() bool {
 	if grepOutput("lsmod", "^linuwu_sense ") {
 		return true
 	}
-	return runOutput("dkms", "status", "linuwu_sense") != ""
+	return grepOutput("dkms status", `^linuwu[-_]sense[/,]`)
 }
 func hasRust() bool {
 	return runAsUser("bash", "-c", `source "$HOME/.cargo/env" 2>/dev/null && which cargo`) == nil

--- a/predator-sense-gui/setup.sh
+++ b/predator-sense-gui/setup.sh
@@ -42,10 +42,12 @@ is_module_loaded() {
 }
 
 # linuwu_sense (and DAMX, which builds on it) already replaces acer_wmi and
-# claims the same WMI GUIDs facer needs. The two can't coexist.
+# claims the same WMI GUIDs facer needs. The two can't coexist. DKMS registers
+# the package as linuwu-sense while the module it builds is linuwu_sense, so the
+# two names have to be matched separately.
 is_linuwu_sense_present() {
     lsmod | awk '{print $1}' | grep -qx linuwu_sense && return 0
-    dkms status linuwu_sense 2>/dev/null | grep -q .
+    dkms status 2>/dev/null | grep -q '^linuwu[-_]sense[/,]'
 }
 
 is_hotkey_active() {

--- a/scripts/remote-install.sh
+++ b/scripts/remote-install.sh
@@ -399,8 +399,10 @@ if dkms add -m "$DKMS_MODULE" -v "$DKMS_VERSION" > "$MAKE_LOG" 2>&1 \
     # claims the same WMI GUIDs facer needs. If it's installed, the blacklist +
     # facer swap below would fight it and break a setup that already works, so
     # don't touch the platform driver — RGB is driven over HID regardless.
+    # DKMS registers the package as linuwu-sense while the module it builds is
+    # linuwu_sense, so the two names have to be matched separately.
     if lsmod | awk '{print $1}' | grep -qx linuwu_sense \
-        || dkms status linuwu_sense 2>/dev/null | grep -q .; then
+        || dkms status 2>/dev/null | grep -q '^linuwu[-_]sense[/,]'; then
         # Drop a facer.conf left by an earlier predator-sense run, otherwise
         # systemd-modules-load would still pull facer up next to linuwu_sense
         # on the next boot and reintroduce the conflict.


### PR DESCRIPTION
Follow-up to #16. You asked me to check the guard still fires on my Linuwu-Sense box — it does, but only by luck, and I found a bug in it while checking. It's my bug from #16, and it got carried into `setup.sh` and the Go installer when you ported the guard in f32fd2b.

## The problem

The guard has two halves:

```bash
lsmod | awk '{print $1}' | grep -qx linuwu_sense \
    || dkms status linuwu_sense 2>/dev/null | grep -q .
```

The DKMS half never fires. DKMS registers the package as **`linuwu-sense`** — `linuwu_sense` is only the name of the module it builds. On my machine:

```
$ dkms status
linuwu-sense/div, 7.1.3-arch1-1, x86_64: installed

$ dkms status linuwu_sense
(nothing)
```

So `grep -q .` gets an empty stream and the `lsmod` check has been doing all the work.

## Why it matters

It only bites when Linuwu-Sense is installed but not loaded right now — after a kernel upgrade before the reboot, or while someone has it `rmmod`'d during troubleshooting. The DKMS half exists precisely to cover that case. Right now the guard misses it, the installer blacklists `acer_wmi` and writes `facer.conf`, and both drivers come up together on the next boot — the exact conflict the guard was added to prevent.

## The fix

Grep the full `dkms status` output for either spelling, in all three installers:

```bash
dkms status 2>/dev/null | grep -q '^linuwu[-_]sense[/,]'
```

The trailing `[/,]` anchors it against both dkms output formats — older dkms prints `name, version, kernel, arch: status`, newer prints `name/version, kernel, arch: status`.

Same change in `installer/main.go`, switched to `grepOutput` so it can use the same pattern:

```go
return grepOutput("dkms status", `^linuwu[-_]sense[/,]`)
```

## Testing

On this box (`linuwu-sense/div` DKMS-installed, module loaded), I probed the old and new predicates directly rather than running a full install:

- old DKMS check → `false`
- new DKMS check → `true`
- `linuwuSensePresent()` → `true`

`bash -n` clean on both scripts, Go installer compiles clean and `gofmt` reports no diff.

Stock `acer_wmi` machines are unaffected — both halves are false there, so the blacklist + facer swap runs exactly as before. I haven't run a full install on a plain `acer_wmi` machine.
