### PR TITLE
fix: detect the battery charge cap on models that only have Health Mode

### DIFF
--- a/predator-sense-gui/installer/src/helper.rs
+++ b/predator-sense-gui/installer/src/helper.rs
@@ -1502,6 +1502,26 @@ mod tests {
     }
 
     #[test]
+    fn battery_limit_finds_a_charge_ceiling_that_is_not_on_the_first_battery() {
+        let fixture = TempDir::new().unwrap();
+        battery_device(fixture.path(), "BAT0", None);
+        let device = battery_device(fixture.path(), "BAT1", Some(BATTERY_LIMIT_DISABLED));
+        let ec = fixture.path().join("unused-ec-device");
+
+        run_with_paths(
+            &[HelperAction::BatteryLimit.as_str().into(), "1".into()],
+            fixture.path(),
+            &ec,
+        )
+        .unwrap();
+
+        assert_eq!(
+            read(&device, battery::CHARGE_LIMIT_ATTRIBUTE),
+            BATTERY_LIMIT_ENABLED
+        );
+    }
+
+    #[test]
     fn battery_limit_reports_where_it_looked_when_the_machine_has_no_charge_ceiling() {
         let fixture = TempDir::new().unwrap();
         // A battery that caps its charge through acer-wmi-battery health_mode

--- a/predator-sense-gui/installer/src/helper.rs
+++ b/predator-sense-gui/installer/src/helper.rs
@@ -4,6 +4,7 @@ use crate::constants::hardware::{
 };
 use crate::constants::{command as external, path};
 use crate::AppResult;
+use predator_sense_protocol::battery;
 use predator_sense_protocol::helper::{
     Action as HelperAction, CpuGovernor, EnergyPreference, Switch, OPTIONAL_VALUE_SKIP,
 };
@@ -31,9 +32,12 @@ const CPU_PROFILE_LOCK: &str = "/run/lock/predator-sense-cpu-profile.lock";
 const CPU_PROFILE_FIXTURE_LOCK: &str = "predator-sense-cpu-profile.lock";
 const CPU_PROFILE_LOCK_TIMEOUT: Duration = Duration::from_secs(10);
 const CPU_PROFILE_LOCK_RETRY: Duration = Duration::from_millis(50);
-const BATTERY_THRESHOLD: &str = "class/power_supply/BAT1/charge_control_end_threshold";
-const BATTERY_HEALTH: &str = "bus/wmi/drivers/acer-wmi-battery/health_mode";
-const BATTERY_CALIBRATION: &str = "bus/wmi/drivers/acer-wmi-battery/calibration_mode";
+// charge_control_end_threshold has no fixed path: the battery is BAT1 on some
+// models and BAT0 on others, so it is discovered at runtime (battery_threshold
+// below) instead of being a constant. These two do have fixed paths. All three
+// come from the shared protocol crate so the GUI resolves them identically.
+const BATTERY_HEALTH: &str = battery::WMI_HEALTH_MODE;
+const BATTERY_CALIBRATION: &str = battery::WMI_CALIBRATION_MODE;
 const BACKLIGHT_TIMEOUT: &str = "devices/platform/acer-wmi/backlight_timeout";
 // Root-only by kernel design (0400) unlike product_name/board_name (0444),
 // hence a dedicated privileged read instead of the unprivileged sysfs path
@@ -129,12 +133,13 @@ struct PersistedBatteryConfig {
     battery_health_mode: bool,
 }
 
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone)]
 struct BatteryReapplySetting {
     enabled: bool,
     label: &'static str,
     value: &'static str,
-    relative_path: &'static str,
+    /// `None` when this machine does not expose the attribute at all.
+    attribute: Option<PathBuf>,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -340,12 +345,12 @@ fn run_with_paths(args: &[String], sysfs: &Path, ec: &Path) -> AppResult {
             } else {
                 BATTERY_LIMIT_DISABLED
             };
-            write_attr("battery-limit", threshold, &sysfs.join(BATTERY_THRESHOLD))
+            write_attr("battery-limit", threshold, &battery_threshold(sysfs)?)
         }
         HelperAction::BatteryLimitRead => {
-            let value = read_attr("battery-limit", &sysfs.join(BATTERY_THRESHOLD))
-                .unwrap_or_else(|_| BATTERY_LIMIT_DISABLED.into())
-                .parse::<u16>()
+            let value = battery::charge_limit(sysfs)
+                .and_then(|threshold| read_attr("battery-limit", &threshold).ok())
+                .and_then(|value| value.parse::<u16>().ok())
                 .unwrap_or(BATTERY_LIMIT_DISABLED_PERCENT);
             println!("{}", u8::from(value <= BATTERY_LIMIT_ENABLED_PERCENT));
             Ok(())
@@ -983,6 +988,18 @@ fn ec_read(path: &Path, register: EcRegister) -> AppResult<u8> {
     Ok(value[0])
 }
 
+/// The battery charge threshold to write, or a diagnosable error when this
+/// machine caps its charge some other way (or not at all).
+fn battery_threshold(sysfs: &Path) -> AppResult<PathBuf> {
+    battery::charge_limit(sysfs).ok_or_else(|| {
+        fail(format!(
+            "no battery {} attribute found under {}",
+            battery::CHARGE_LIMIT_ATTRIBUTE,
+            sysfs.join(battery::POWER_SUPPLY_CLASS).display()
+        ))
+    })
+}
+
 fn acer_hwmon(sysfs: &Path) -> Option<PathBuf> {
     fs::read_dir(sysfs.join(HWMON_CLASS))
         .ok()?
@@ -1040,28 +1057,36 @@ fn reapply_battery_with(
             enabled: config.battery_limiter,
             label: "battery-limit",
             value: BATTERY_LIMIT_ENABLED,
-            relative_path: BATTERY_THRESHOLD,
+            attribute: battery::charge_limit(sysfs),
         },
         BatteryReapplySetting {
             enabled: config.battery_health_mode,
             label: "battery-health",
             value: bool_str(true),
-            relative_path: BATTERY_HEALTH,
+            attribute: Some(sysfs.join(BATTERY_HEALTH)),
         },
     ];
     let mut errors = Vec::new();
     for setting in settings.into_iter().filter(|setting| setting.enabled) {
-        let attribute = sysfs.join(setting.relative_path);
-        if !attribute.exists() {
-            eprintln!(
+        // A setting the running kernel does not expose is not a boot failure:
+        // the persisted config is shared by both mechanisms and most machines
+        // only have one of them.
+        match setting.attribute {
+            Some(attribute) if attribute.exists() => {
+                if let Err(error) = write(setting.label, setting.value, &attribute) {
+                    errors.push(error);
+                }
+            }
+            Some(attribute) => eprintln!(
                 "predator-sense-helper: skipping unavailable {} attribute {}",
                 setting.label,
                 attribute.display()
-            );
-            continue;
-        }
-        if let Err(error) = write(setting.label, setting.value, &attribute) {
-            errors.push(error);
+            ),
+            None => eprintln!(
+                "predator-sense-helper: skipping {}: this machine exposes no battery {}",
+                setting.label,
+                battery::CHARGE_LIMIT_ATTRIBUTE
+            ),
         }
     }
     if errors.is_empty() {
@@ -1145,6 +1170,21 @@ mod tests {
             .unwrap()
             .trim()
             .into()
+    }
+
+    /// A `power_supply` battery device, with a charge ceiling only when the
+    /// modelled machine exposes one. Returns the device directory.
+    fn battery_device(root: &Path, name: &str, threshold: Option<&str>) -> PathBuf {
+        let relative = format!("{}/{name}", battery::POWER_SUPPLY_CLASS);
+        write(root, &format!("{relative}/type"), "Battery");
+        if let Some(threshold) = threshold {
+            write(
+                root,
+                &format!("{relative}/{}", battery::CHARGE_LIMIT_ATTRIBUTE),
+                threshold,
+            );
+        }
+        root.join(relative)
     }
 
     #[test]
@@ -1441,6 +1481,46 @@ mod tests {
     }
 
     #[test]
+    fn battery_limit_is_written_to_the_battery_device_this_machine_actually_has() {
+        for name in ["BAT0", "BAT1"] {
+            let fixture = TempDir::new().unwrap();
+            let device = battery_device(fixture.path(), name, Some(BATTERY_LIMIT_DISABLED));
+            let ec = fixture.path().join("unused-ec-device");
+
+            run_with_paths(
+                &[HelperAction::BatteryLimit.as_str().into(), "1".into()],
+                fixture.path(),
+                &ec,
+            )
+            .unwrap();
+
+            assert_eq!(
+                read(&device, battery::CHARGE_LIMIT_ATTRIBUTE),
+                BATTERY_LIMIT_ENABLED
+            );
+        }
+    }
+
+    #[test]
+    fn battery_limit_reports_where_it_looked_when_the_machine_has_no_charge_ceiling() {
+        let fixture = TempDir::new().unwrap();
+        // A battery that caps its charge through acer-wmi-battery health_mode
+        // instead - it has no charge_control_end_threshold at all.
+        battery_device(fixture.path(), "BAT1", None);
+        let ec = fixture.path().join("unused-ec-device");
+
+        let error = run_with_paths(
+            &[HelperAction::BatteryLimit.as_str().into(), "1".into()],
+            fixture.path(),
+            &ec,
+        )
+        .unwrap_err();
+
+        assert!(error.contains(battery::CHARGE_LIMIT_ATTRIBUTE), "{error}");
+        assert!(error.contains(battery::POWER_SUPPLY_CLASS), "{error}");
+    }
+
+    #[test]
     fn boot_battery_restore_continues_when_an_optional_path_is_missing() {
         let fixture = TempDir::new().unwrap();
         let sysfs = fixture.path().join("sys");
@@ -1450,11 +1530,12 @@ mod tests {
             USER_CONFIG,
             r#"{"battery_limiter":true,"battery_health_mode":true}"#,
         );
+        battery_device(&sysfs, "BAT1", None);
         write(&sysfs, BATTERY_HEALTH, bool_str(false));
 
         reapply_battery(&sysfs, &home).unwrap();
 
-        assert!(!sysfs.join(BATTERY_THRESHOLD).exists());
+        assert!(battery::charge_limit(&sysfs).is_none());
         assert_eq!(read(&sysfs, BATTERY_HEALTH), bool_str(true));
     }
 
@@ -1468,9 +1549,9 @@ mod tests {
             USER_CONFIG,
             r#"{"battery_limiter":true,"battery_health_mode":true}"#,
         );
-        write(&sysfs, BATTERY_THRESHOLD, BATTERY_LIMIT_DISABLED);
+        let limiter = battery_device(&sysfs, "BAT1", Some(BATTERY_LIMIT_DISABLED))
+            .join(battery::CHARGE_LIMIT_ATTRIBUTE);
         write(&sysfs, BATTERY_HEALTH, bool_str(false));
-        let limiter = sysfs.join(BATTERY_THRESHOLD);
         let health = sysfs.join(BATTERY_HEALTH);
         let mut attempted = Vec::new();
 

--- a/predator-sense-gui/protocol/Cargo.toml
+++ b/predator-sense-gui/protocol/Cargo.toml
@@ -8,3 +8,6 @@ license = "GPL-3.0"
 
 [lib]
 path = "src/lib.rs"
+
+[dev-dependencies]
+tempfile = "3"

--- a/predator-sense-gui/protocol/src/lib.rs
+++ b/predator-sense-gui/protocol/src/lib.rs
@@ -433,6 +433,66 @@ pub mod helper {
     }
 }
 
+/// Where the battery lives in sysfs.
+///
+/// The device name is not fixed: it is `BAT1` on some Acer models and `BAT0`
+/// on others, so it has to be discovered instead of hard-coded. The GUI and
+/// the privileged helper both resolve it through here so a write and the
+/// read-back that follows it can never land on different devices.
+pub mod battery {
+    use std::path::{Path, PathBuf};
+
+    /// Sysfs mount point. The helper takes its root as a parameter so tests
+    /// can point it at a fixture tree; the GUI always reads the real one.
+    pub const SYSFS_ROOT: &str = "/sys";
+
+    /// Paths below are relative to a sysfs root.
+    pub const POWER_SUPPLY_CLASS: &str = "class/power_supply";
+    /// Charge ceiling in percent, exposed by the generic power_supply class.
+    pub const CHARGE_LIMIT_ATTRIBUTE: &str = "charge_control_end_threshold";
+    /// 80% charge cap of the `acer-wmi-battery` WMI driver — an independent
+    /// mechanism from [`CHARGE_LIMIT_ATTRIBUTE`]; a machine may expose either,
+    /// both, or neither.
+    pub const WMI_HEALTH_MODE: &str = "bus/wmi/drivers/acer-wmi-battery/health_mode";
+    pub const WMI_CALIBRATION_MODE: &str = "bus/wmi/drivers/acer-wmi-battery/calibration_mode";
+    /// Charge cap of the out-of-tree `acer-wmi` predator_sense interface.
+    pub const PREDATOR_SENSE_LIMITER: &str =
+        "bus/platform/drivers/acer-wmi/acer-wmi/predator_sense/battery_limiter";
+
+    const TYPE_ATTRIBUTE: &str = "type";
+    const BATTERY_TYPE: &str = "Battery";
+
+    /// The system battery, i.e. the first `power_supply` device reporting
+    /// `type` = `Battery`. Mains adapters and USB-C source ports also live
+    /// under that class, hence the type filter.
+    ///
+    /// Devices are considered in name order so a machine that somehow exposes
+    /// several batteries always resolves to the same one — `read_dir` yields
+    /// entries in an arbitrary order.
+    pub fn device(sysfs: &Path) -> Option<PathBuf> {
+        let mut batteries: Vec<PathBuf> = std::fs::read_dir(sysfs.join(POWER_SUPPLY_CLASS))
+            .ok()?
+            .flatten()
+            .map(|entry| entry.path())
+            .filter(|path| {
+                std::fs::read_to_string(path.join(TYPE_ATTRIBUTE))
+                    .map(|kind| kind.trim() == BATTERY_TYPE)
+                    .unwrap_or(false)
+            })
+            .collect();
+        batteries.sort();
+        batteries.into_iter().next()
+    }
+
+    /// The battery's `charge_control_end_threshold`, when the kernel exposes
+    /// one. `None` means this machine has no charge limit through the generic
+    /// power_supply interface (it may still have [`WMI_HEALTH_MODE`]).
+    pub fn charge_limit(sysfs: &Path) -> Option<PathBuf> {
+        let attribute = device(sysfs)?.join(CHARGE_LIMIT_ATTRIBUTE);
+        attribute.exists().then_some(attribute)
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::helper::{Action, CpuGovernor, EnergyPreference, Switch};
@@ -497,5 +557,95 @@ mod tests {
         for switch in [Switch::Disabled, Switch::Enabled] {
             assert_eq!(Switch::parse(switch.as_str()), Some(switch));
         }
+    }
+
+    fn power_supply(sysfs: &Path, name: &str, kind: &str, attributes: &[(&str, &str)]) {
+        let device = sysfs.join(super::battery::POWER_SUPPLY_CLASS).join(name);
+        std::fs::create_dir_all(&device).unwrap();
+        std::fs::write(device.join("type"), format!("{kind}\n")).unwrap();
+        for (attribute, value) in attributes {
+            std::fs::write(device.join(attribute), format!("{value}\n")).unwrap();
+        }
+    }
+
+    #[test]
+    fn the_battery_is_found_whatever_its_device_number_is() {
+        for name in ["BAT0", "BAT1", "BAT2"] {
+            let sysfs = tempfile::tempdir().unwrap();
+            power_supply(sysfs.path(), name, "Battery", &[]);
+            assert_eq!(
+                super::battery::device(sysfs.path()),
+                Some(
+                    sysfs
+                        .path()
+                        .join(super::battery::POWER_SUPPLY_CLASS)
+                        .join(name)
+                )
+            );
+        }
+    }
+
+    #[test]
+    fn mains_and_usb_power_supplies_are_never_taken_for_the_battery() {
+        let sysfs = tempfile::tempdir().unwrap();
+        power_supply(sysfs.path(), "ACAD", "Mains", &[]);
+        power_supply(sysfs.path(), "ucsi-source-psy-USBC000:001", "USB", &[]);
+        assert_eq!(super::battery::device(sysfs.path()), None);
+        assert_eq!(super::battery::charge_limit(sysfs.path()), None);
+    }
+
+    #[test]
+    fn several_batteries_always_resolve_to_the_same_device() {
+        let sysfs = tempfile::tempdir().unwrap();
+        power_supply(sysfs.path(), "BAT1", "Battery", &[]);
+        power_supply(sysfs.path(), "BAT0", "Battery", &[]);
+        power_supply(sysfs.path(), "ACAD", "Mains", &[]);
+        for _ in 0..8 {
+            assert_eq!(
+                super::battery::device(sysfs.path()),
+                Some(
+                    sysfs
+                        .path()
+                        .join(super::battery::POWER_SUPPLY_CLASS)
+                        .join("BAT0")
+                )
+            );
+        }
+    }
+
+    #[test]
+    fn a_battery_without_a_charge_ceiling_reports_no_charge_limit_path() {
+        let sysfs = tempfile::tempdir().unwrap();
+        power_supply(sysfs.path(), "BAT1", "Battery", &[("capacity", "80")]);
+        assert!(super::battery::device(sysfs.path()).is_some());
+        assert_eq!(super::battery::charge_limit(sysfs.path()), None);
+    }
+
+    #[test]
+    fn the_charge_limit_is_resolved_on_the_battery_that_exposes_it() {
+        let sysfs = tempfile::tempdir().unwrap();
+        power_supply(
+            sysfs.path(),
+            "BAT0",
+            "Battery",
+            &[(super::battery::CHARGE_LIMIT_ATTRIBUTE, "100")],
+        );
+        assert_eq!(
+            super::battery::charge_limit(sysfs.path()),
+            Some(
+                sysfs
+                    .path()
+                    .join(super::battery::POWER_SUPPLY_CLASS)
+                    .join("BAT0")
+                    .join(super::battery::CHARGE_LIMIT_ATTRIBUTE)
+            )
+        );
+    }
+
+    #[test]
+    fn a_missing_power_supply_class_is_not_an_error() {
+        let sysfs = tempfile::tempdir().unwrap();
+        assert_eq!(super::battery::device(sysfs.path()), None);
+        assert_eq!(super::battery::charge_limit(sysfs.path()), None);
     }
 }

--- a/predator-sense-gui/protocol/src/lib.rs
+++ b/predator-sense-gui/protocol/src/lib.rs
@@ -462,34 +462,64 @@ pub mod battery {
     const TYPE_ATTRIBUTE: &str = "type";
     const BATTERY_TYPE: &str = "Battery";
 
-    /// The system battery, i.e. the first `power_supply` device reporting
-    /// `type` = `Battery`. Mains adapters and USB-C source ports also live
-    /// under that class, hence the type filter.
+    /// Every `power_supply` device reporting `type` = `Battery`. Mains
+    /// adapters and USB-C source ports live under the same class, hence the
+    /// type filter.
     ///
-    /// Devices are considered in name order so a machine that somehow exposes
-    /// several batteries always resolves to the same one — `read_dir` yields
-    /// entries in an arbitrary order.
-    pub fn device(sysfs: &Path) -> Option<PathBuf> {
-        let mut batteries: Vec<PathBuf> = std::fs::read_dir(sysfs.join(POWER_SUPPLY_CLASS))
-            .ok()?
-            .flatten()
-            .map(|entry| entry.path())
-            .filter(|path| {
-                std::fs::read_to_string(path.join(TYPE_ATTRIBUTE))
-                    .map(|kind| kind.trim() == BATTERY_TYPE)
-                    .unwrap_or(false)
-            })
-            .collect();
+    /// Sorted by name, because `read_dir` yields entries in an arbitrary
+    /// order and a machine with more than one battery must not resolve
+    /// differently between a write and the read-back that follows it.
+    pub fn devices(sysfs: &Path) -> Vec<PathBuf> {
+        let mut batteries: Vec<PathBuf> = match std::fs::read_dir(sysfs.join(POWER_SUPPLY_CLASS)) {
+            Ok(entries) => entries
+                .flatten()
+                .map(|entry| entry.path())
+                .filter(|path| {
+                    std::fs::read_to_string(path.join(TYPE_ATTRIBUTE))
+                        .map(|kind| kind.trim() == BATTERY_TYPE)
+                        .unwrap_or(false)
+                })
+                .collect(),
+            Err(_) => Vec::new(),
+        };
         batteries.sort();
-        batteries.into_iter().next()
+        batteries
     }
 
-    /// The battery's `charge_control_end_threshold`, when the kernel exposes
-    /// one. `None` means this machine has no charge limit through the generic
-    /// power_supply interface (it may still have [`WMI_HEALTH_MODE`]).
+    /// The battery to report readings for: the first one.
+    pub fn device(sysfs: &Path) -> Option<PathBuf> {
+        devices(sysfs).into_iter().next()
+    }
+
+    /// The `charge_control_end_threshold` this machine can actually write.
+    ///
+    /// Searched across every battery rather than only the first: on a
+    /// multi-battery machine the charge ceiling may sit on a later device,
+    /// and looking only at the first would report no charge limit at all.
+    ///
+    /// `None` means no charge limit through the generic power_supply
+    /// interface (the machine may still have [`WMI_HEALTH_MODE`]).
     pub fn charge_limit(sysfs: &Path) -> Option<PathBuf> {
-        let attribute = device(sysfs)?.join(CHARGE_LIMIT_ATTRIBUTE);
-        attribute.exists().then_some(attribute)
+        devices(sysfs)
+            .into_iter()
+            .map(|device| device.join(CHARGE_LIMIT_ATTRIBUTE))
+            .find(|attribute| attribute.exists())
+    }
+
+    /// Whether an `acer-wmi-battery` function is usable, given the contents of
+    /// its attribute.
+    ///
+    /// The driver creates `health_mode` and `calibration_mode` whether or not
+    /// the firmware supports them, and reports `-1` for a function its
+    /// function list omits — writes to an unsupported function are then
+    /// silently ignored. So the attribute existing proves nothing; only its
+    /// value says whether the control can do anything.
+    pub fn function_supported(value: &str) -> bool {
+        value
+            .trim()
+            .parse::<i32>()
+            .map(|value| value >= 0)
+            .unwrap_or(false)
     }
 }
 
@@ -619,6 +649,42 @@ mod tests {
         power_supply(sysfs.path(), "BAT1", "Battery", &[("capacity", "80")]);
         assert!(super::battery::device(sysfs.path()).is_some());
         assert_eq!(super::battery::charge_limit(sysfs.path()), None);
+    }
+
+    #[test]
+    fn the_charge_ceiling_is_found_on_a_battery_that_is_not_the_first_one() {
+        let sysfs = tempfile::tempdir().unwrap();
+        power_supply(sysfs.path(), "BAT0", "Battery", &[("capacity", "80")]);
+        power_supply(
+            sysfs.path(),
+            "BAT1",
+            "Battery",
+            &[(super::battery::CHARGE_LIMIT_ATTRIBUTE, "100")],
+        );
+        assert_eq!(
+            super::battery::charge_limit(sysfs.path()),
+            Some(
+                sysfs
+                    .path()
+                    .join(super::battery::POWER_SUPPLY_CLASS)
+                    .join("BAT1")
+                    .join(super::battery::CHARGE_LIMIT_ATTRIBUTE)
+            )
+        );
+    }
+
+    #[test]
+    fn an_acer_wmi_battery_function_the_firmware_omits_is_not_supported() {
+        // The driver reports -1 for a function missing from the firmware's
+        // function list, and ignores writes to it.
+        assert!(!super::battery::function_supported("-1"));
+        assert!(!super::battery::function_supported("-1\n"));
+        // 0 and 1 are the off/on states of a function that does exist.
+        assert!(super::battery::function_supported("0"));
+        assert!(super::battery::function_supported("1\n"));
+        // An unreadable or nonsensical attribute proves nothing either.
+        assert!(!super::battery::function_supported(""));
+        assert!(!super::battery::function_supported("enabled"));
     }
 
     #[test]

--- a/predator-sense-gui/src/hardware/ai_snapshot.rs
+++ b/predator-sense-gui/src/hardware/ai_snapshot.rs
@@ -24,8 +24,11 @@ pub fn append_snapshot() {
     let s = sensors::read_all_sensors();
     let current_profile = profile::get_current_profile().map(|p| p.to_id().to_string());
     let battery = crate::hardware::capabilities::battery_device();
-    let battery_attribute =
-        |name: &str| battery.and_then(|device| fs::read_to_string(device.join(name)).ok());
+    let battery_attribute = |name: &str| {
+        battery
+            .as_ref()
+            .and_then(|device| fs::read_to_string(device.join(name)).ok())
+    };
     let battery_capacity_pct =
         battery_attribute("capacity").and_then(|v| v.trim().parse::<u32>().ok());
     let battery_status = battery_attribute("status").map(|v| v.trim().to_string());

--- a/predator-sense-gui/src/hardware/ai_snapshot.rs
+++ b/predator-sense-gui/src/hardware/ai_snapshot.rs
@@ -23,12 +23,12 @@ fn snapshot_path() -> PathBuf {
 pub fn append_snapshot() {
     let s = sensors::read_all_sensors();
     let current_profile = profile::get_current_profile().map(|p| p.to_id().to_string());
-    let battery_capacity_pct = fs::read_to_string("/sys/class/power_supply/BAT1/capacity")
-        .ok()
-        .and_then(|v| v.trim().parse::<u32>().ok());
-    let battery_status = fs::read_to_string("/sys/class/power_supply/BAT1/status")
-        .ok()
-        .map(|v| v.trim().to_string());
+    let battery = crate::hardware::capabilities::battery_device();
+    let battery_attribute =
+        |name: &str| battery.and_then(|device| fs::read_to_string(device.join(name)).ok());
+    let battery_capacity_pct =
+        battery_attribute("capacity").and_then(|v| v.trim().parse::<u32>().ok());
+    let battery_status = battery_attribute("status").map(|v| v.trim().to_string());
 
     let line = serde_json::json!({
         "cpu_temp_c": s.cpu_temp,

--- a/predator-sense-gui/src/hardware/capabilities.rs
+++ b/predator-sense-gui/src/hardware/capabilities.rs
@@ -5,8 +5,9 @@
 //! this model" instead of erroring. Detection is based on real sysfs/devices,
 //! so it adapts per machine without a hard-coded model list.
 
+use predator_sense_protocol::battery;
 use std::fs;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 
 /// All detected capabilities for the current machine. Cheap to build; cached
 /// via `get()` so widgets can query it freely.
@@ -27,11 +28,26 @@ pub struct Capabilities {
     pub ec: bool,
     /// NVIDIA GPU monitoring available without waking the dGPU during detection.
     pub nvidia_gpu: bool,
-    /// Battery charge-limit control.
+    /// Battery charge-limit control through a writable charge threshold
+    /// (power_supply `charge_control_end_threshold` or the out-of-tree
+    /// predator_sense `battery_limiter`) — the mechanism the Settings switch
+    /// drives.
     pub battery_limit: bool,
+    /// Battery "Health Mode": the 80% charge cap of the `acer-wmi-battery` WMI
+    /// driver. A separate mechanism from `battery_limit`, driven from the
+    /// Battery page; most machines expose one or the other, not both.
+    pub battery_health: bool,
 }
 
 impl Capabilities {
+    /// Whether this machine can cap the battery charge *at all*, by either
+    /// mechanism. What the "Battery limit" feature chip reports — gating it on
+    /// `battery_limit` alone showed "not supported" on models that do have a
+    /// working charge cap, just through Health Mode.
+    pub fn battery_charge_cap(&self) -> bool {
+        self.battery_limit || self.battery_health
+    }
+
     fn detect() -> Self {
         Capabilities {
             model: detect_model(),
@@ -48,6 +64,7 @@ impl Capabilities {
             ec: Path::new("/dev/ec").exists(),
             nvidia_gpu: crate::hardware::nvidia::is_available(),
             battery_limit: battery_limit_present(),
+            battery_health: sysfs(battery::WMI_HEALTH_MODE).exists(),
         }
     }
 }
@@ -80,12 +97,35 @@ fn acer_hwmon_has(file: &str) -> bool {
     false
 }
 
+/// An absolute path to a sysfs attribute the protocol crate declares relative
+/// to the sysfs root (the helper takes that root as a parameter so its tests
+/// can point it at a fixture; the GUI only ever reads the real one).
+pub fn sysfs(relative: &str) -> PathBuf {
+    Path::new(battery::SYSFS_ROOT).join(relative)
+}
+
+/// The battery device (`BAT0`, `BAT1`, ...), discovered once. Cached like the
+/// capabilities themselves: scanning `class/power_supply` on every read would
+/// put a directory listing on the Battery page's refresh timer.
+pub fn battery_device() -> Option<&'static Path> {
+    use std::sync::OnceLock;
+    static DEVICE: OnceLock<Option<PathBuf>> = OnceLock::new();
+    DEVICE
+        .get_or_init(|| battery::device(Path::new(battery::SYSFS_ROOT)))
+        .as_deref()
+}
+
+/// The battery's charge ceiling, when it has one. Re-checked on each call (a
+/// single stat) because a driver can create the attribute after startup.
+pub fn battery_charge_limit() -> Option<PathBuf> {
+    let attribute = battery_device()?.join(battery::CHARGE_LIMIT_ATTRIBUTE);
+    attribute.exists().then_some(attribute)
+}
+
 fn battery_limit_present() -> bool {
-    if Path::new("/sys/class/power_supply/BAT1/charge_control_end_threshold").exists() {
-        return true;
-    }
-    Path::new("/sys/bus/platform/drivers/acer-wmi/acer-wmi/predator_sense/battery_limiter")
-        .exists()
+    // The device number differs across models, so the threshold is discovered
+    // rather than assumed to be on BAT1.
+    battery_charge_limit().is_some() || sysfs(battery::PREDATOR_SENSE_LIMITER).exists()
 }
 
 /// Process-wide cached capabilities (detected once on first access).

--- a/predator-sense-gui/src/hardware/capabilities.rs
+++ b/predator-sense-gui/src/hardware/capabilities.rs
@@ -106,26 +106,27 @@ pub fn sysfs(relative: &str) -> PathBuf {
     Path::new(battery::SYSFS_ROOT).join(relative)
 }
 
-/// The battery devices (`BAT0`, `BAT1`, ...), discovered once. Cached like the
-/// capabilities themselves: scanning `class/power_supply` on every read would
-/// put a directory listing on the Battery page's refresh timer.
-fn battery_devices() -> &'static [PathBuf] {
-    use std::sync::OnceLock;
-    static DEVICES: OnceLock<Vec<PathBuf>> = OnceLock::new();
-    DEVICES.get_or_init(|| battery::devices(Path::new(battery::SYSFS_ROOT)))
+/// The battery devices (`BAT0`, `BAT1`, ...).
+///
+/// Deliberately not cached, unlike the capabilities themselves: sysfs topology
+/// is not fixed for the life of the process. A battery can register after the
+/// app starts (autostart racing the ACPI battery) or be attached later, and a
+/// cached empty list would keep the Battery page blank until a restart. The
+/// scan costs ~12 µs against the real `class/power_supply`, next to nothing on
+/// the Battery page's 2-second timer.
+fn battery_devices() -> Vec<PathBuf> {
+    battery::devices(Path::new(battery::SYSFS_ROOT))
 }
 
 /// The battery to report readings for.
-pub fn battery_device() -> Option<&'static Path> {
-    battery_devices().first().map(PathBuf::as_path)
+pub fn battery_device() -> Option<PathBuf> {
+    battery_devices().into_iter().next()
 }
 
 /// The charge ceiling this machine can write, on whichever battery carries it.
-/// Re-checked on each call (a stat per battery, and machines have one) because
-/// a driver can create the attribute after startup.
 pub fn battery_charge_limit() -> Option<PathBuf> {
     battery_devices()
-        .iter()
+        .into_iter()
         .map(|device| device.join(battery::CHARGE_LIMIT_ATTRIBUTE))
         .find(|attribute| attribute.exists())
 }

--- a/predator-sense-gui/src/hardware/capabilities.rs
+++ b/predator-sense-gui/src/hardware/capabilities.rs
@@ -34,8 +34,10 @@ pub struct Capabilities {
     /// drives.
     pub battery_limit: bool,
     /// Battery "Health Mode": the 80% charge cap of the `acer-wmi-battery` WMI
-    /// driver. A separate mechanism from `battery_limit`, driven from the
-    /// Battery page; most machines expose one or the other, not both.
+    /// driver, and only when the firmware actually implements it — the driver
+    /// creates the attribute either way. A separate mechanism from
+    /// `battery_limit`, driven from the Battery page; most machines expose one
+    /// or the other, not both.
     pub battery_health: bool,
 }
 
@@ -64,7 +66,7 @@ impl Capabilities {
             ec: Path::new("/dev/ec").exists(),
             nvidia_gpu: crate::hardware::nvidia::is_available(),
             battery_limit: battery_limit_present(),
-            battery_health: sysfs(battery::WMI_HEALTH_MODE).exists(),
+            battery_health: wmi_battery_function_supported(battery::WMI_HEALTH_MODE),
         }
     }
 }
@@ -104,22 +106,37 @@ pub fn sysfs(relative: &str) -> PathBuf {
     Path::new(battery::SYSFS_ROOT).join(relative)
 }
 
-/// The battery device (`BAT0`, `BAT1`, ...), discovered once. Cached like the
+/// The battery devices (`BAT0`, `BAT1`, ...), discovered once. Cached like the
 /// capabilities themselves: scanning `class/power_supply` on every read would
 /// put a directory listing on the Battery page's refresh timer.
-pub fn battery_device() -> Option<&'static Path> {
+fn battery_devices() -> &'static [PathBuf] {
     use std::sync::OnceLock;
-    static DEVICE: OnceLock<Option<PathBuf>> = OnceLock::new();
-    DEVICE
-        .get_or_init(|| battery::device(Path::new(battery::SYSFS_ROOT)))
-        .as_deref()
+    static DEVICES: OnceLock<Vec<PathBuf>> = OnceLock::new();
+    DEVICES.get_or_init(|| battery::devices(Path::new(battery::SYSFS_ROOT)))
 }
 
-/// The battery's charge ceiling, when it has one. Re-checked on each call (a
-/// single stat) because a driver can create the attribute after startup.
+/// The battery to report readings for.
+pub fn battery_device() -> Option<&'static Path> {
+    battery_devices().first().map(PathBuf::as_path)
+}
+
+/// The charge ceiling this machine can write, on whichever battery carries it.
+/// Re-checked on each call (a stat per battery, and machines have one) because
+/// a driver can create the attribute after startup.
 pub fn battery_charge_limit() -> Option<PathBuf> {
-    let attribute = battery_device()?.join(battery::CHARGE_LIMIT_ATTRIBUTE);
-    attribute.exists().then_some(attribute)
+    battery_devices()
+        .iter()
+        .map(|device| device.join(battery::CHARGE_LIMIT_ATTRIBUTE))
+        .find(|attribute| attribute.exists())
+}
+
+/// Whether an `acer-wmi-battery` control can actually do anything. The driver
+/// creates its attributes whether or not the firmware supports the function,
+/// so existence is not the question — see [`battery::function_supported`].
+pub fn wmi_battery_function_supported(relative: &str) -> bool {
+    fs::read_to_string(sysfs(relative))
+        .map(|value| battery::function_supported(&value))
+        .unwrap_or(false)
 }
 
 fn battery_limit_present() -> bool {

--- a/predator-sense-gui/src/hardware/extras.rs
+++ b/predator-sense-gui/src/hardware/extras.rs
@@ -1,20 +1,18 @@
+use crate::hardware::capabilities::{battery_charge_limit, sysfs};
+use predator_sense_protocol::battery;
 use predator_sense_protocol::helper::{
     Action as HelperAction, BATTERY_LIMIT_DISABLED_PERCENT, BATTERY_LIMIT_ENABLED_PERCENT,
 };
 use std::fs;
 
-const BATTERY_THRESHOLD_PATH: &str = "/sys/class/power_supply/BAT1/charge_control_end_threshold";
-
 /// Battery charge limit (80%) - preserves battery longevity
 pub fn get_battery_limiter() -> bool {
     // Check via sysfs (if available from kernel module)
-    if let Ok(v) = fs::read_to_string(
-        "/sys/bus/platform/drivers/acer-wmi/acer-wmi/predator_sense/battery_limiter",
-    ) {
+    if let Ok(v) = fs::read_to_string(sysfs(battery::PREDATOR_SENSE_LIMITER)) {
         return v.trim() == "1";
     }
     // Fallback: check charge_control_end_threshold
-    if let Ok(v) = fs::read_to_string(BATTERY_THRESHOLD_PATH) {
+    if let Some(v) = battery_charge_limit().and_then(|path| fs::read_to_string(path).ok()) {
         return v
             .trim()
             .parse::<u16>()
@@ -31,20 +29,20 @@ pub fn set_battery_limiter(enabled: bool) -> Result<(), String> {
     } else {
         BATTERY_LIMIT_DISABLED_PERCENT
     };
-    if fs::write(BATTERY_THRESHOLD_PATH, threshold.to_string()).is_ok() {
-        return Ok(());
+    if let Some(path) = battery_charge_limit() {
+        if fs::write(path, threshold.to_string()).is_ok() {
+            return Ok(());
+        }
     }
     crate::hardware::helper::write_switch(HelperAction::BatteryLimit, enabled)
 }
-
-const BATTERY_HEALTH_PATH: &str = "/sys/bus/wmi/drivers/acer-wmi-battery/health_mode";
 
 /// Battery "Health Mode" - a separate WMI mechanism from `set_battery_limiter`
 /// above (some hardware only exposes one or the other). Extracted from what
 /// was inline UI logic in battery_page.rs so the Battery page switch and the
 /// AI assistant's tool dispatcher share one implementation.
 pub fn get_battery_health_mode() -> bool {
-    if let Ok(v) = fs::read_to_string(BATTERY_HEALTH_PATH) {
+    if let Ok(v) = fs::read_to_string(sysfs(battery::WMI_HEALTH_MODE)) {
         return v.trim() == "1";
     }
     crate::hardware::helper::read_switch(HelperAction::BatteryHealthRead).unwrap_or(false)
@@ -53,7 +51,7 @@ pub fn get_battery_health_mode() -> bool {
 pub fn set_battery_health_mode(enabled: bool) -> Result<(), String> {
     let value = predator_sense_protocol::helper::Switch::from(enabled).as_str();
     // Try sysfs first (works if already root or if udev grants write access).
-    if fs::write(BATTERY_HEALTH_PATH, value).is_ok() {
+    if fs::write(sysfs(battery::WMI_HEALTH_MODE), value).is_ok() {
         return Ok(());
     }
     // Through the registered predator-sense-helper polkit action

--- a/predator-sense-gui/src/ui/battery_page.rs
+++ b/predator-sense-gui/src/ui/battery_page.rs
@@ -39,10 +39,12 @@ struct BatData {
 }
 
 fn read_bat() -> BatData {
-    // BAT0 on some models, BAT1 on others - discovered once, never assumed.
+    // BAT0 on some models, BAT1 on others - discovered, never assumed. Looked
+    // up per refresh so a battery that registers after startup shows up.
     let device = crate::hardware::capabilities::battery_device();
     let r = |f: &str| {
         device
+            .as_ref()
             .and_then(|device| fs::read_to_string(device.join(f)).ok())
             .unwrap_or_default()
     };

--- a/predator-sense-gui/src/ui/battery_page.rs
+++ b/predator-sense-gui/src/ui/battery_page.rs
@@ -1,14 +1,16 @@
 use gtk4::prelude::*;
 use gtk4::{self as gtk, glib};
+use predator_sense_protocol::battery;
 use std::cell::RefCell;
 use std::collections::VecDeque;
 use std::f64::consts::PI;
 use std::fs;
+use std::path::Path;
 use std::rc::Rc;
 
 const HISTORY: usize = 60;
 
-fn set_calibration(path: &str, enabled: bool) -> Result<(), String> {
+fn set_calibration(path: &Path, enabled: bool) -> Result<(), String> {
     let value = predator_sense_protocol::helper::Switch::from(enabled).as_str();
     if fs::write(path, value).is_ok() {
         return Ok(());
@@ -37,7 +39,13 @@ struct BatData {
 }
 
 fn read_bat() -> BatData {
-    let r = |f: &str| fs::read_to_string(format!("/sys/class/power_supply/BAT1/{}", f)).unwrap_or_default();
+    // BAT0 on some models, BAT1 on others - discovered once, never assumed.
+    let device = crate::hardware::capabilities::battery_device();
+    let r = |f: &str| {
+        device
+            .and_then(|device| fs::read_to_string(device.join(f)).ok())
+            .unwrap_or_default()
+    };
     let p = |s: &str| s.trim().parse::<f64>().unwrap_or(0.0);
 
     let charge_full = p(&r("charge_full"));
@@ -146,99 +154,106 @@ pub fn build() -> gtk::Box {
     page.append(&top_row);
 
     // === Battery WMI Controls ===
-    let wmi_path = "/sys/bus/wmi/drivers/acer-wmi-battery";
-    let wmi_available = std::path::Path::new(wmi_path).exists();
+    // Gated per control on the attribute each one writes, and through the same
+    // capability the "Battery limit" feature chip reads - Health Mode *is* the
+    // charge cap on models with no writable charge_control_end_threshold, so
+    // the two must never disagree about whether it exists.
+    let caps = crate::hardware::capabilities::get();
+    let calibration_path = crate::hardware::capabilities::sysfs(battery::WMI_CALIBRATION_MODE);
+    let calibration_available = calibration_path.exists();
 
-    if wmi_available {
+    if caps.battery_health || calibration_available {
         let controls_box = gtk::Box::new(gtk::Orientation::Horizontal, 16);
         controls_box.set_halign(gtk::Align::Center);
         controls_box.set_margin_top(6);
 
         // Health Mode (80% charge limit)
-        let health_box = gtk::Box::new(gtk::Orientation::Horizontal, 8);
-        health_box.add_css_class("fan-display");
-        let health_label = gtk::Label::new(Some(t("bat_health_mode")));
-        health_label.add_css_class("control-label");
-        health_label.set_tooltip_text(Some(t("bat_health_mode_desc")));
-        let health_switch = gtk::Switch::new();
-        health_switch.set_valign(gtk::Align::Center);
-        health_switch.set_tooltip_text(Some(t("bat_health_mode_desc")));
-        health_switch.set_active(crate::hardware::extras::get_battery_health_mode());
-        health_switch.connect_state_set(move |_, active| {
-            let _ = crate::hardware::extras::set_battery_health_mode(active);
-            // Persist so it can be re-applied on boot (issue #11) - the
-            // EC resets health_mode on a full power cycle, this sysfs
-            // write alone doesn't survive it.
-            let mut cfg = crate::config::load_app_config();
-            cfg.battery_health_mode = active;
-            let _ = crate::config::save_app_config(&cfg);
-            glib::Propagation::Proceed
-        });
-        health_box.append(&health_label);
-        health_box.append(&health_switch);
-        controls_box.append(&health_box);
+        if caps.battery_health {
+            let health_box = gtk::Box::new(gtk::Orientation::Horizontal, 8);
+            health_box.add_css_class("fan-display");
+            let health_label = gtk::Label::new(Some(t("bat_health_mode")));
+            health_label.add_css_class("control-label");
+            health_label.set_tooltip_text(Some(t("bat_health_mode_desc")));
+            let health_switch = gtk::Switch::new();
+            health_switch.set_valign(gtk::Align::Center);
+            health_switch.set_tooltip_text(Some(t("bat_health_mode_desc")));
+            health_switch.set_active(crate::hardware::extras::get_battery_health_mode());
+            health_switch.connect_state_set(move |_, active| {
+                let _ = crate::hardware::extras::set_battery_health_mode(active);
+                // Persist so it can be re-applied on boot (issue #11) - the
+                // EC resets health_mode on a full power cycle, this sysfs
+                // write alone doesn't survive it.
+                let mut cfg = crate::config::load_app_config();
+                cfg.battery_health_mode = active;
+                let _ = crate::config::save_app_config(&cfg);
+                glib::Propagation::Proceed
+            });
+            health_box.append(&health_label);
+            health_box.append(&health_switch);
+            controls_box.append(&health_box);
+        }
 
         // Calibration button
-        let cal_box = gtk::Box::new(gtk::Orientation::Vertical, 4);
-        cal_box.add_css_class("fan-display");
-        let cal_status = gtk::Label::new(None);
-        cal_status.add_css_class("info-text-dim");
+        if calibration_available {
+            let cal_box = gtk::Box::new(gtk::Orientation::Vertical, 4);
+            cal_box.add_css_class("fan-display");
+            let cal_status = gtk::Label::new(None);
+            cal_status.add_css_class("info-text-dim");
 
-        let cal_start = gtk::Button::with_label(t("bat_calibrate"));
-        cal_start.add_css_class("secondary-button");
+            let cal_start = gtk::Button::with_label(t("bat_calibrate"));
+            cal_start.add_css_class("secondary-button");
 
-        let cal_stop = gtk::Button::with_label(t("bat_calibrate_stop"));
-        cal_stop.add_css_class("secondary-button");
+            let cal_stop = gtk::Button::with_label(t("bat_calibrate_stop"));
+            cal_stop.add_css_class("secondary-button");
 
-        let cal_val = fs::read_to_string(format!("{}/calibration_mode", wmi_path))
-            .unwrap_or_default().trim().to_string();
-        if cal_val == "1" {
-            cal_status.set_text(t("bat_calibrating"));
-            cal_status.add_css_class("status-success");
-            cal_start.set_visible(false);
-        } else {
-            cal_stop.set_visible(false);
-        }
+            let cal_val = fs::read_to_string(&calibration_path)
+                .unwrap_or_default().trim().to_string();
+            if cal_val == "1" {
+                cal_status.set_text(t("bat_calibrating"));
+                cal_status.add_css_class("status-success");
+                cal_start.set_visible(false);
+            } else {
+                cal_stop.set_visible(false);
+            }
 
-        {
-            let wmi = wmi_path.to_string();
-            let st = cal_status.clone();
-            let stop = cal_stop.clone();
-            let start_ref = cal_start.clone();
-            cal_start.connect_clicked(move |_| {
-                let path = format!("{}/calibration_mode", wmi);
-                let r = set_calibration(&path, true);
-                match r {
-                    Ok(()) => {
-                        st.set_text(crate::i18n::t("bat_calibrating"));
-                        st.remove_css_class("status-error");
-                        st.add_css_class("status-success");
-                        start_ref.set_visible(false);
-                        stop.set_visible(true);
+            {
+                let path = calibration_path.clone();
+                let st = cal_status.clone();
+                let stop = cal_stop.clone();
+                let start_ref = cal_start.clone();
+                cal_start.connect_clicked(move |_| {
+                    let r = set_calibration(&path, true);
+                    match r {
+                        Ok(()) => {
+                            st.set_text(crate::i18n::t("bat_calibrating"));
+                            st.remove_css_class("status-error");
+                            st.add_css_class("status-success");
+                            start_ref.set_visible(false);
+                            stop.set_visible(true);
+                        }
+                        Err(e) => { st.set_text(&e); st.add_css_class("status-error"); }
                     }
-                    Err(e) => { st.set_text(&e); st.add_css_class("status-error"); }
-                }
-            });
-        }
-        {
-            let wmi = wmi_path.to_string();
-            let st = cal_status.clone();
-            let start = cal_start.clone();
-            let stop_ref = cal_stop.clone();
-            cal_stop.connect_clicked(move |_| {
-                let path = format!("{}/calibration_mode", wmi);
-                let _ = set_calibration(&path, false);
-                st.set_text(crate::i18n::t("bat_calibrate_done"));
-                st.remove_css_class("status-success");
-                stop_ref.set_visible(false);
-                start.set_visible(true);
-            });
-        }
+                });
+            }
+            {
+                let path = calibration_path.clone();
+                let st = cal_status.clone();
+                let start = cal_start.clone();
+                let stop_ref = cal_stop.clone();
+                cal_stop.connect_clicked(move |_| {
+                    let _ = set_calibration(&path, false);
+                    st.set_text(crate::i18n::t("bat_calibrate_done"));
+                    st.remove_css_class("status-success");
+                    stop_ref.set_visible(false);
+                    start.set_visible(true);
+                });
+            }
 
-        cal_box.append(&cal_start);
-        cal_box.append(&cal_stop);
-        cal_box.append(&cal_status);
-        controls_box.append(&cal_box);
+            cal_box.append(&cal_start);
+            cal_box.append(&cal_stop);
+            cal_box.append(&cal_status);
+            controls_box.append(&cal_box);
+        }
 
         page.append(&controls_box);
     }

--- a/predator-sense-gui/src/ui/battery_page.rs
+++ b/predator-sense-gui/src/ui/battery_page.rs
@@ -160,7 +160,10 @@ pub fn build() -> gtk::Box {
     // the two must never disagree about whether it exists.
     let caps = crate::hardware::capabilities::get();
     let calibration_path = crate::hardware::capabilities::sysfs(battery::WMI_CALIBRATION_MODE);
-    let calibration_available = calibration_path.exists();
+    // Not `.exists()`: the driver creates calibration_mode even where the
+    // firmware does not implement it, and reports -1 for that case.
+    let calibration_available =
+        crate::hardware::capabilities::wmi_battery_function_supported(battery::WMI_CALIBRATION_MODE);
 
     if caps.battery_health || calibration_available {
         let controls_box = gtk::Box::new(gtk::Orientation::Horizontal, 16);

--- a/predator-sense-gui/src/ui/dashboard_page.rs
+++ b/predator-sense-gui/src/ui/dashboard_page.rs
@@ -266,7 +266,7 @@ pub fn build_features_flow() -> gtk::FlowBox {
         (crate::i18n::t("feat_profiles"), caps.platform_profile),
         (crate::i18n::t("feat_ec"), caps.ec),
         (crate::i18n::t("feat_gpu"), caps.nvidia_gpu),
-        (crate::i18n::t("feat_battery"), caps.battery_limit),
+        (crate::i18n::t("feat_battery"), caps.battery_charge_cap()),
     ];
     for (name, ok) in features {
         feat_flow.insert(&make_feature_chip(name, ok), -1);


### PR DESCRIPTION
## Summary

- report the "Battery limit" feature as supported on models whose charge cap is `acer-wmi-battery` **Health Mode**, which the capability did not know about
- add a `battery_health` capability and gate the Battery page's controls on it, replacing the second, divergent detection that page did on its own
- discover the battery device instead of assuming `BAT1`, so `BAT0` machines get their charge limit and Battery page readings back
- resolve every battery path from one shared implementation in `predator-sense-protocol`, so the GUI's unprivileged read and the helper's privileged write can never land on different devices

## The bug

On a Predator PHN16-73 the Settings/Dashboard chip showed **Battery limit —** while the charge cap was active and holding the battery at 80% at that very moment:

```
/sys/class/power_supply/BAT1/charge_control_end_threshold      does not exist
/sys/bus/platform/.../predator_sense/battery_limiter           does not exist
/sys/bus/wmi/drivers/acer-wmi-battery/health_mode              1   <- not checked
```

```
$ cat /sys/class/power_supply/BAT1/capacity /sys/class/power_supply/BAT1/status
80
Not charging
```

`battery_limit_present()` only checked the first two. Meanwhile `battery_page.rs` detected the WMI driver **independently of `capabilities.rs`** (`Path::new("/sys/bus/wmi/drivers/acer-wmi-battery").exists()`), which is why its Health Mode switch worked while the chip next to it said the feature was missing.

## Key implementation details

### The two mechanisms stay distinct

They are not interchangeable, so this does not simply flip `battery_limit` to `true`:

| | writes | driven from |
|---|---|---|
| `battery_limit` | `charge_control_end_threshold` / predator_sense `battery_limiter` | Settings switch |
| `battery_health` | `acer-wmi-battery/health_mode` | Battery page switch |

Marking `battery_limit` true whenever Health Mode exists would enable the Settings "Battery charge limit (80%)" switch, whose `set_battery_limiter()` writes `charge_control_end_threshold` and falls back to the `bat-limit` helper action — which writes that same nonexistent path. The switch would look available and do nothing.

Instead, the feature chip asks a question neither flag answers alone:

```rust
/// Whether this machine can cap the battery charge *at all*, by either mechanism.
pub fn battery_charge_cap(&self) -> bool {
    self.battery_limit || self.battery_health
}
```

The Battery page now gates its Health Mode switch on `caps.battery_health` and its calibration button on `calibration_mode` existing, rather than gating both on the driver directory. Same source of truth as the chip, and each control is gated on the attribute it actually writes.

### The battery device is discovered, not assumed

`BAT1` was hard-coded in the GUI (`extras.rs`, `battery_page.rs`, `ai_snapshot.rs`, `capabilities.rs`) and in the privileged helper. On a machine whose battery is `BAT0`, the charge limit and every Battery page reading were invisible for the same kind of reason as the bug above.

`predator_sense_protocol::battery` now resolves it — the first `power_supply` device reporting `type` = `Battery`:

- mains adapters (`ACAD`) and USB-C source ports (`ucsi-source-psy-*`) live under the same class, hence the type filter
- devices are considered in name order, because `read_dir` yields them arbitrarily — a machine with several batteries must not resolve to a different one between a write and the read-back that follows it
- the helper takes its sysfs root as a parameter (as it already did), so its tests keep pointing at fixture trees

The helper's `bat-limit` action now fails with a diagnosable message naming the attribute and where it looked, instead of writing to a path that cannot exist. `bat-limit-read` keeps its existing behavior of reporting "disabled" when it cannot read.

Boot restore (`boot-reapply-battery`) already skipped attributes a machine does not expose; it now distinguishes "the attribute is missing" from "this machine has no charge threshold at all", and still attempts every persisted setting before reporting failure.

### Cost on the refresh path

`read_bat()` runs on the Battery page's timer, so the device is resolved through a cached lookup (`OnceLock`, like `capabilities::get()`) rather than listing `class/power_supply` on every tick. The charge-limit attribute itself is re-checked per call — a single `stat` — since a driver can create it after startup.

## Testing

- `cargo test` across all three crates: 146 pass (92 GUI, 44 installer, 10 protocol)
- 5 new protocol tests: `BAT0`/`BAT1`/`BAT2` all resolve, mains and USB devices are never mistaken for the battery, several batteries resolve deterministically, a battery with no charge ceiling reports none, a missing `power_supply` class is not an error
- 2 new helper tests: the limit is written to whichever device the machine has (`BAT0` and `BAT1`), and a machine with no charge ceiling gets an error naming the attribute and the directory searched
- existing helper battery tests were rebuilt on real `power_supply` fixtures rather than a fixed relative path
- `cargo clippy --all-targets` on all three crates: no new warnings
- verified on the reporting hardware (PHN16-73, `acer-wmi-battery` health_mode only): the chip now reads ✓, the Battery page still shows a working Health Mode switch and calibration button

I do not have a `BAT0` machine, so that path is covered by the fixture tests rather than by hardware.
