### PR TITLE
fix(kernel): decode the thermal profile with the numbering its transport uses

### DIFF
--- a/predator-sense-gui/kernel/facer.c
+++ b/predator-sense-gui/kernel/facer.c
@@ -1404,6 +1404,44 @@ enum acer_predator_v4_thermal_profile_wmi {
 	ACER_PREDATOR_V4_THERMAL_PROFILE_BALANCED_WMI = 0x010B,
 };
 
+/*
+ * Raw profile indices as the WMI interface numbers them - the high byte of the
+ * *_WMI command values just above, and the same values upstream acer-wmi uses
+ * in its enum acer_predator_v4_thermal_profile.
+ *
+ * This is NOT the EC numbering: the EC offset counts 0..4 in a different order.
+ * Both exist because both interfaces exist, and the profile they name is only
+ * the same profile after the right one is used for the right transport.
+ */
+enum acer_predator_v4_thermal_profile_wmi_index {
+	ACER_PREDATOR_V4_THERMAL_PROFILE_WMI_QUIET	 = 0x00,
+	ACER_PREDATOR_V4_THERMAL_PROFILE_WMI_BALANCED	 = 0x01,
+	ACER_PREDATOR_V4_THERMAL_PROFILE_WMI_PERFORMANCE = 0x04,
+	ACER_PREDATOR_V4_THERMAL_PROFILE_WMI_TURBO	 = 0x05,
+	ACER_PREDATOR_V4_THERMAL_PROFILE_WMI_ECO	 = 0x06,
+};
+
+/*
+ * Which numbering platform_profile speaks, chosen by which transport it uses:
+ * WMI from 6.14 on (WMID_gaming_{get,set}_misc_setting), the EC offset before
+ * that. Reading a WMI value and comparing it against EC constants is how the
+ * supported-profiles bitmask ended up half-decoded and the names ended up
+ * attached to the wrong power levels.
+ */
+#if RTLNX_VER_MIN(6, 14, 0)
+#define ACER_PP_QUIET		ACER_PREDATOR_V4_THERMAL_PROFILE_WMI_QUIET
+#define ACER_PP_BALANCED	ACER_PREDATOR_V4_THERMAL_PROFILE_WMI_BALANCED
+#define ACER_PP_PERFORMANCE	ACER_PREDATOR_V4_THERMAL_PROFILE_WMI_PERFORMANCE
+#define ACER_PP_TURBO		ACER_PREDATOR_V4_THERMAL_PROFILE_WMI_TURBO
+#define ACER_PP_ECO		ACER_PREDATOR_V4_THERMAL_PROFILE_WMI_ECO
+#else
+#define ACER_PP_QUIET		ACER_PREDATOR_V4_THERMAL_PROFILE_QUIET
+#define ACER_PP_BALANCED	ACER_PREDATOR_V4_THERMAL_PROFILE_BALANCED
+#define ACER_PP_PERFORMANCE	ACER_PREDATOR_V4_THERMAL_PROFILE_PERFORMANCE
+#define ACER_PP_TURBO		ACER_PREDATOR_V4_THERMAL_PROFILE_TURBO
+#define ACER_PP_ECO		ACER_PREDATOR_V4_THERMAL_PROFILE_ECO
+#endif
+
 /* Find which quirks are needed for a particular vendor/ model pair */
 static void __init find_quirks(void)
 {
@@ -3362,19 +3400,19 @@ acer_predator_v4_platform_profile_get(struct platform_profile_handler *pprof,
 #endif
 
 	switch (tp) {
-	case ACER_PREDATOR_V4_THERMAL_PROFILE_TURBO:
+	case ACER_PP_TURBO:
 		*profile = PLATFORM_PROFILE_PERFORMANCE;
 		break;
-	case ACER_PREDATOR_V4_THERMAL_PROFILE_PERFORMANCE:
+	case ACER_PP_PERFORMANCE:
 		*profile = PLATFORM_PROFILE_BALANCED_PERFORMANCE;
 		break;
-	case ACER_PREDATOR_V4_THERMAL_PROFILE_BALANCED:
+	case ACER_PP_BALANCED:
 		*profile = PLATFORM_PROFILE_BALANCED;
 		break;
-	case ACER_PREDATOR_V4_THERMAL_PROFILE_QUIET:
+	case ACER_PP_QUIET:
 		*profile = PLATFORM_PROFILE_QUIET;
 		break;
-	case ACER_PREDATOR_V4_THERMAL_PROFILE_ECO:
+	case ACER_PP_ECO:
 		*profile = PLATFORM_PROFILE_LOW_POWER;
 		break;
 	default:
@@ -3398,19 +3436,19 @@ acer_predator_v4_platform_profile_set(struct platform_profile_handler *pprof,
 
 	switch (profile) {
 	case PLATFORM_PROFILE_PERFORMANCE:
-		tp = ACER_PREDATOR_V4_THERMAL_PROFILE_TURBO;
+		tp = ACER_PP_TURBO;
 		break;
 	case PLATFORM_PROFILE_BALANCED_PERFORMANCE:
-		tp = ACER_PREDATOR_V4_THERMAL_PROFILE_PERFORMANCE;
+		tp = ACER_PP_PERFORMANCE;
 		break;
 	case PLATFORM_PROFILE_BALANCED:
-		tp = ACER_PREDATOR_V4_THERMAL_PROFILE_BALANCED;
+		tp = ACER_PP_BALANCED;
 		break;
 	case PLATFORM_PROFILE_QUIET:
-		tp = ACER_PREDATOR_V4_THERMAL_PROFILE_QUIET;
+		tp = ACER_PP_QUIET;
 		break;
 	case PLATFORM_PROFILE_LOW_POWER:
-		tp = ACER_PREDATOR_V4_THERMAL_PROFILE_ECO;
+		tp = ACER_PP_ECO;
 		break;
 	default:
 		return -EOPNOTSUPP;
@@ -3457,45 +3495,45 @@ acer_predator_v4_platform_profile_probe(void *drvdata, unsigned long *choices)
 		return err;
 
 	/* Iterate through supported profiles in order of increasing performance */
-	if (test_bit(ACER_PREDATOR_V4_THERMAL_PROFILE_ECO, &supported_profiles)) {
+	if (test_bit(ACER_PP_ECO, &supported_profiles)) {
 		set_bit(PLATFORM_PROFILE_LOW_POWER, choices);
-		acer_predator_v4_max_perf = ACER_PREDATOR_V4_THERMAL_PROFILE_ECO;
-		last_non_turbo_profile = ACER_PREDATOR_V4_THERMAL_PROFILE_ECO;
+		acer_predator_v4_max_perf = ACER_PP_ECO;
+		last_non_turbo_profile = ACER_PP_ECO;
 	}
 
-	if (test_bit(ACER_PREDATOR_V4_THERMAL_PROFILE_QUIET, &supported_profiles)) {
+	if (test_bit(ACER_PP_QUIET, &supported_profiles)) {
 		set_bit(PLATFORM_PROFILE_QUIET, choices);
-		acer_predator_v4_max_perf = ACER_PREDATOR_V4_THERMAL_PROFILE_QUIET;
-		last_non_turbo_profile = ACER_PREDATOR_V4_THERMAL_PROFILE_QUIET;
+		acer_predator_v4_max_perf = ACER_PP_QUIET;
+		last_non_turbo_profile = ACER_PP_QUIET;
 	}
 
-	if (test_bit(ACER_PREDATOR_V4_THERMAL_PROFILE_BALANCED, &supported_profiles)) {
+	if (test_bit(ACER_PP_BALANCED, &supported_profiles)) {
 		set_bit(PLATFORM_PROFILE_BALANCED, choices);
-		acer_predator_v4_max_perf = ACER_PREDATOR_V4_THERMAL_PROFILE_BALANCED;
-		last_non_turbo_profile = ACER_PREDATOR_V4_THERMAL_PROFILE_BALANCED;
+		acer_predator_v4_max_perf = ACER_PP_BALANCED;
+		last_non_turbo_profile = ACER_PP_BALANCED;
 	}
 
-	if (test_bit(ACER_PREDATOR_V4_THERMAL_PROFILE_PERFORMANCE, &supported_profiles)) {
+	if (test_bit(ACER_PP_PERFORMANCE, &supported_profiles)) {
 		set_bit(PLATFORM_PROFILE_BALANCED_PERFORMANCE, choices);
-		acer_predator_v4_max_perf = ACER_PREDATOR_V4_THERMAL_PROFILE_PERFORMANCE;
+		acer_predator_v4_max_perf = ACER_PP_PERFORMANCE;
 
 		/* We only use this profile as a fallback option in case no prior
 		 * profile is supported.
 		 */
 		if (last_non_turbo_profile < 0)
-			last_non_turbo_profile = ACER_PREDATOR_V4_THERMAL_PROFILE_PERFORMANCE;
+			last_non_turbo_profile = ACER_PP_PERFORMANCE;
 	}
 
-	if (test_bit(ACER_PREDATOR_V4_THERMAL_PROFILE_TURBO, &supported_profiles)) {
+	if (test_bit(ACER_PP_TURBO, &supported_profiles)) {
 		set_bit(PLATFORM_PROFILE_PERFORMANCE, choices);
-		acer_predator_v4_max_perf = ACER_PREDATOR_V4_THERMAL_PROFILE_TURBO;
+		acer_predator_v4_max_perf = ACER_PP_TURBO;
 
 		/* We need to handle the hypothetical case where only the turbo profile
 		 * is supported. In this case the turbo toggle will essentially be a
 		 * no-op.
 		 */
 		if (last_non_turbo_profile < 0)
-			last_non_turbo_profile = ACER_PREDATOR_V4_THERMAL_PROFILE_TURBO;
+			last_non_turbo_profile = ACER_PP_TURBO;
 	}
 
 	return 0;


### PR DESCRIPTION
## Summary

- decode the Predator v4 thermal profile with the numbering its **transport** uses, instead of reading a WMI value and comparing it against EC constants
- restores the correspondence between `platform_profile` names and the power they deliver — three names were attached to the wrong level, and two profiles had no name at all
- offers all five profiles instead of three: the supported-profiles bitmask is read over WMI and was being tested at the wrong bit positions
- pre-6.14 EC behaviour is unchanged

## The two numberings

`facer.c` already carries both, and they disagree — this is not one enum being wrong, it is two interfaces counting differently:

| profile | EC offset (`0x54`) | WMI (`SetGamingMiscSetting 0x0B`) |
|---|---:|---:|
| BALANCED | 0x00 | 0x01 |
| QUIET | 0x01 | 0x00 |
| PERFORMANCE | 0x02 | 0x04 |
| TURBO | 0x03 | 0x05 |
| ECO | 0x04 | 0x06 |

The WMI column is the high byte of the `*_WMI` command values already defined a few lines below the EC enum (`ECO_WMI = 0x060B` → index 6), and it matches upstream `acer-wmi`'s `enum acer_predator_v4_thermal_profile` exactly.

`platform_profile` moved to WMI on 6.14 (`WMID_gaming_{get,set}_misc_setting`) but kept the EC constants in its switch statements, so on that path every value crossed the boundary undecoded.

## Measured, before and after

Predator PHN16-73, Core Ultra 9 275HX, BIOS V1.26, supported bitmask `0x73`. Each profile written through `platform_profile`, package limit read back from `intel-rapl-mmio`:

| `platform_profile` | before: index → PL1 | after: index → PL1 |
|---|---|---|
| `low-power` | 4 → **95 W** | 6 → **45 W** |
| `quiet` | 1 → 70 W | 0 → 55 W |
| `balanced` | 0 → **55 W** | 1 → 70 W |
| `balanced-performance` | *not offered* | 4 → 95 W |
| `performance` | *not offered* | 5 → **115 W** |

Before, `low-power` was the second **strongest** profile and `balanced` was weaker than `quiet`. After, the five names run monotonically: 45 → 55 → 70 → 95 → 115 W.

Reading back per index also works now. Previously, with the firmware on index 5 or 6, `cat /sys/firmware/acpi/platform_profile` returned `EOPNOTSUPP`, because neither value matched any `case`:

```
before                                   after
raw=5 -> Operation not supported         raw=5 -> performance            115 W
raw=6 -> Operation not supported         raw=6 -> low-power               45 W
```

## Why only three profiles were offered

`acer_predator_v4_platform_profile_probe()` reads the supported-profiles bitmask over WMI and then tests it with EC constants. With `0x73` (bits 0, 1, 4, 5, 6):

| test | bit | set? | result |
|---|---:|:---:|---|
| `ECO` = 0x04 | 4 | yes | offered `low-power` (but index 4 is 95 W) |
| `QUIET` = 0x01 | 1 | yes | offered `quiet` |
| `BALANCED` = 0x00 | 0 | yes | offered `balanced` |
| `PERFORMANCE` = 0x02 | 2 | **no** | missing |
| `TURBO` = 0x03 | 3 | **no** | missing |

Exactly the three that `platform_profile_choices` listed. The two the machine could not reach were its 115 W and 45 W ends.

## The change

Both numberings stay, since both interfaces do. `ACER_PP_*` resolves to whichever the active transport speaks, so the three `platform_profile` callbacks stop crossing the boundary while the pre-6.14 EC path keeps its current values byte for byte.

`acer_thermal_profile_change()` is deliberately untouched: it reads the EC and compares EC constants, which was already consistent.

## Relation to #32

#32 worked around this by measuring each index at runtime and ranking by observed power, on the premise that the driver's naming does not follow the power order on this firmware. That premise was wrong: the naming upstream is correct, and what did not follow was this file decoding WMI values as EC ones. The measured ladder in that PR matches upstream's enum exactly, which is what pointed here.

The calibration still has its own value — it does not depend on any table and covers firmware that genuinely diverges — but this machine was never a divergent firmware, and I intend to correct that claim in the PR description and the two READMEs separately.

## Known issue this does not fix

`last_non_turbo_profile` is written in two different formats by different callers: a bare index from the probe and from `platform_profile_set`, and `0x010B`-style command values from `acer_platform_profile_setup()` and `acer_thermal_profile_change()`. Its only reader, `acer_thermal_profile_change()`, uses it as a command value.

This predates the patch and is not made worse by it, but the patch does change *which* bare value the probe stores. I could not verify that path on this hardware — the mode key on a PHN16-73 reports over EC HID and never raises the WMI event that reaches it (see #32) — so I left it alone rather than change code I cannot test. Flagging it for someone with hardware that does raise it.

## Testing

- measured as tabulated above, module rebuilt and reloaded on real hardware for each direction
- installed through the project installer afterwards, so DKMS carries it across reboots; `platform_profile_choices` still lists all five after a clean rebuild
- `cargo test`: 119 passing, unchanged — no userspace code is touched
- the raw `thermal_profile` / `thermal_profile_supported` attributes from #32 still read correctly, the hotkey daemon is still active, and `turbo_state` still reads
