### PR TITLE
fix(battery): treat the 80% health mode as one mechanism with two drivers

### DIFF
--- a/predator-sense-gui/installer/src/helper.rs
+++ b/predator-sense-gui/installer/src/helper.rs
@@ -37,7 +37,6 @@ const CPU_PROFILE_LOCK_RETRY: Duration = Duration::from_millis(50);
 // models and BAT0 on others, so it is discovered at runtime (battery_threshold
 // below) instead of being a constant. These two do have fixed paths. All three
 // come from the shared protocol crate so the GUI resolves them identically.
-const BATTERY_HEALTH: &str = battery::WMI_HEALTH_MODE;
 const BATTERY_CALIBRATION: &str = battery::WMI_CALIBRATION_MODE;
 const BACKLIGHT_TIMEOUT: &str = "devices/platform/acer-wmi/backlight_timeout";
 // Root-only by kernel design (0400) unlike product_name/board_name (0444),
@@ -358,14 +357,11 @@ fn run_with_paths(args: &[String], sysfs: &Path, ec: &Path) -> AppResult {
         }
         HelperAction::BatteryHealth => {
             let enabled = parse_bool(&args[1])?;
-            write_attr(
-                "battery-health",
-                bool_str(enabled),
-                &sysfs.join(BATTERY_HEALTH),
-            )
+            write_attr("battery-health", bool_str(enabled), &health_mode(sysfs)?)
         }
         HelperAction::BatteryHealthRead => {
-            let value = read_attr("battery-health", &sysfs.join(BATTERY_HEALTH))
+            let value = health_mode(sysfs)
+                .and_then(|path| read_attr("battery-health", &path))
                 .unwrap_or_else(|_| bool_str(false).into());
             println!("{value}");
             Ok(())
@@ -1021,6 +1017,20 @@ fn ec_read(path: &Path, register: EcRegister) -> AppResult<u8> {
 
 /// The battery charge threshold to write, or a diagnosable error when this
 /// machine caps its charge some other way (or not at all).
+/// The health-mode control, whichever driver exposes it.
+///
+/// `acer-wmi-battery` names it `health_mode` and Linuwu-Sense names it
+/// `battery_limiter`, but both issue the same firmware call, so either will do
+/// and a machine needs only one of them.
+fn health_mode(sysfs: &Path) -> AppResult<PathBuf> {
+    battery::health_mode_control(sysfs).ok_or_else(|| {
+        fail(format!(
+            "no usable battery health-mode control found under {}",
+            sysfs.display()
+        ))
+    })
+}
+
 fn battery_threshold(sysfs: &Path) -> AppResult<PathBuf> {
     battery::charge_limit(sysfs).ok_or_else(|| {
         fail(format!(
@@ -1094,7 +1104,7 @@ fn reapply_battery_with(
             enabled: config.battery_health_mode,
             label: "battery-health",
             value: bool_str(true),
-            attribute: Some(sysfs.join(BATTERY_HEALTH)),
+            attribute: battery::health_mode_control(sysfs),
         },
     ];
     let mut errors = Vec::new();
@@ -1211,6 +1221,9 @@ fn set_gpu_power_limit(
 
 #[cfg(test)]
 mod tests {
+    /// Fixtures write the in-tree driver's attribute; `health_mode_control`
+    /// accepts either backend, and this is the one a stock machine has.
+    const BATTERY_HEALTH: &str = battery::WMI_HEALTH_MODE;
     use super::*;
     use tempfile::TempDir;
 
@@ -1677,6 +1690,65 @@ mod tests {
     /// The whole point of the boot service: the firmware forgets the profile
     /// on every power cycle, landing on an index that is not even in its own
     /// supported set.
+    /// A machine whose only health-mode control is Linuwu-Sense's
+    /// `battery_limiter`. It is the same firmware call under another name, so
+    /// the health action has to reach it - before this it wrote to the in-tree
+    /// path unconditionally and failed on exactly these machines.
+    #[test]
+    fn the_health_action_uses_whichever_driver_is_present() {
+        let fixture = TempDir::new().unwrap();
+        let sysfs = fixture.path().join("sys");
+        write(&sysfs, battery::PREDATOR_SENSE_LIMITER, bool_str(false));
+
+        run_with_paths(
+            &[HelperAction::BatteryHealth.as_str().into(), "1".into()],
+            &sysfs,
+            Path::new("/dev/null"),
+        )
+        .unwrap();
+
+        assert_eq!(
+            read(&sysfs, battery::PREDATOR_SENSE_LIMITER),
+            bool_str(true)
+        );
+    }
+
+    /// And the boot restore reaches it too, for the same reason.
+    #[test]
+    fn boot_battery_restore_reaches_the_out_of_tree_health_control() {
+        let fixture = TempDir::new().unwrap();
+        let sysfs = fixture.path().join("sys");
+        let home = fixture.path().join("home/user");
+        write(&home, USER_CONFIG, r#"{"battery_health_mode":true}"#);
+        write(&sysfs, battery::PREDATOR_SENSE_LIMITER, bool_str(false));
+
+        reapply_battery(&sysfs, &home).unwrap();
+
+        assert_eq!(
+            read(&sysfs, battery::PREDATOR_SENSE_LIMITER),
+            bool_str(true)
+        );
+    }
+
+    /// An attribute the firmware does not back reports -1, and must not be
+    /// mistaken for a usable control.
+    #[test]
+    fn an_unsupported_health_attribute_is_not_written_to() {
+        let fixture = TempDir::new().unwrap();
+        let sysfs = fixture.path().join("sys");
+        write(&sysfs, battery::WMI_HEALTH_MODE, "-1");
+
+        let error = run_with_paths(
+            &[HelperAction::BatteryHealth.as_str().into(), "1".into()],
+            &sysfs,
+            Path::new("/dev/null"),
+        )
+        .unwrap_err();
+
+        assert!(error.contains("health-mode"), "{error}");
+        assert_eq!(read(&sysfs, battery::WMI_HEALTH_MODE), "-1", "left alone");
+    }
+
     #[test]
     fn boot_thermal_restore_puts_the_recorded_profile_back() {
         let fixture = TempDir::new().unwrap();

--- a/predator-sense-gui/protocol/src/lib.rs
+++ b/predator-sense-gui/protocol/src/lib.rs
@@ -473,9 +473,39 @@ pub mod battery {
     /// both, or neither.
     pub const WMI_HEALTH_MODE: &str = "bus/wmi/drivers/acer-wmi-battery/health_mode";
     pub const WMI_CALIBRATION_MODE: &str = "bus/wmi/drivers/acer-wmi-battery/calibration_mode";
-    /// Charge cap of the out-of-tree `acer-wmi` predator_sense interface.
+    /// The same 80% health mode as [`WMI_HEALTH_MODE`], exposed by the
+    /// out-of-tree Linuwu-Sense driver under its own name.
+    ///
+    /// Not a second mechanism, despite the name: `predator_battery_limit_store`
+    /// there calls `battery_health_set(HEALTH_MODE, value)`, which is
+    /// `wmi_evaluate_method(WMID_GUID5, 0, 21, ...)` - byte for byte the call
+    /// `acer-wmi-battery` makes for `health_mode`. Whichever driver is loaded,
+    /// the firmware sees one command, so this is a backend of the health mode
+    /// and not of the adjustable charge threshold.
     pub const PREDATOR_SENSE_LIMITER: &str =
         "bus/platform/drivers/acer-wmi/acer-wmi/predator_sense/battery_limiter";
+
+    /// Backends for the 80% health mode, in the order they are preferred.
+    ///
+    /// Both drive the same WMI call; a machine may have either driver loaded,
+    /// and in principle both.
+    pub const HEALTH_MODE_BACKENDS: [&str; 2] = [WMI_HEALTH_MODE, PREDATOR_SENSE_LIMITER];
+
+    /// The health-mode control this machine actually exposes, if any.
+    ///
+    /// Existence is not enough for `acer-wmi-battery`: it creates the attribute
+    /// whether or not the firmware implements the function, and says so by
+    /// reporting -1. See [`function_supported`].
+    pub fn health_mode_control(sysfs: &Path) -> Option<PathBuf> {
+        HEALTH_MODE_BACKENDS
+            .iter()
+            .map(|relative| sysfs.join(relative))
+            .find(|path| {
+                std::fs::read_to_string(path)
+                    .map(|value| function_supported(&value))
+                    .unwrap_or(false)
+            })
+    }
 
     const TYPE_ATTRIBUTE: &str = "type";
     const BATTERY_TYPE: &str = "Battery";
@@ -1085,6 +1115,51 @@ mod tests {
                     .join("BAT0")
                     .join(super::battery::CHARGE_LIMIT_ATTRIBUTE)
             )
+        );
+    }
+
+    /// Linuwu-Sense's `battery_limiter` and acer-wmi-battery's `health_mode`
+    /// are the same firmware call, so either satisfies the health mode - and
+    /// neither satisfies the adjustable charge threshold, which is a genuinely
+    /// different mechanism.
+    #[test]
+    fn either_driver_can_provide_the_health_mode() {
+        let sysfs = tempfile::tempdir().unwrap();
+        assert_eq!(super::battery::health_mode_control(sysfs.path()), None);
+
+        let linuwu = sysfs.path().join(super::battery::PREDATOR_SENSE_LIMITER);
+        std::fs::create_dir_all(linuwu.parent().unwrap()).unwrap();
+        std::fs::write(&linuwu, "0\n").unwrap();
+        assert_eq!(
+            super::battery::health_mode_control(sysfs.path()),
+            Some(linuwu.clone())
+        );
+
+        // With both present the in-tree driver wins, but either alone works.
+        let wmi = sysfs.path().join(super::battery::WMI_HEALTH_MODE);
+        std::fs::create_dir_all(wmi.parent().unwrap()).unwrap();
+        std::fs::write(&wmi, "1\n").unwrap();
+        assert_eq!(super::battery::health_mode_control(sysfs.path()), Some(wmi));
+    }
+
+    /// acer-wmi-battery creates the attribute even where the firmware has no
+    /// such function, and reports -1 there. That is not a usable control, and
+    /// must not mask a driver that does have one.
+    #[test]
+    fn an_unsupported_health_mode_is_not_a_backend() {
+        let sysfs = tempfile::tempdir().unwrap();
+        let wmi = sysfs.path().join(super::battery::WMI_HEALTH_MODE);
+        std::fs::create_dir_all(wmi.parent().unwrap()).unwrap();
+        std::fs::write(&wmi, "-1\n").unwrap();
+        assert_eq!(super::battery::health_mode_control(sysfs.path()), None);
+
+        let linuwu = sysfs.path().join(super::battery::PREDATOR_SENSE_LIMITER);
+        std::fs::create_dir_all(linuwu.parent().unwrap()).unwrap();
+        std::fs::write(&linuwu, "1\n").unwrap();
+        assert_eq!(
+            super::battery::health_mode_control(sysfs.path()),
+            Some(linuwu),
+            "the unsupported in-tree attribute must not hide a working one"
         );
     }
 

--- a/predator-sense-gui/src/hardware/capabilities.rs
+++ b/predator-sense-gui/src/hardware/capabilities.rs
@@ -28,16 +28,23 @@ pub struct Capabilities {
     pub ec: bool,
     /// NVIDIA GPU monitoring available without waking the dGPU during detection.
     pub nvidia_gpu: bool,
-    /// Battery charge-limit control through a writable charge threshold
-    /// (power_supply `charge_control_end_threshold` or the out-of-tree
-    /// predator_sense `battery_limiter`) — the mechanism the Settings switch
-    /// drives.
+    /// Adjustable charge threshold: the generic power_supply
+    /// `charge_control_end_threshold`, which takes a percentage. The mechanism
+    /// the Settings switch drives.
+    ///
+    /// Deliberately does not include the out-of-tree predator_sense
+    /// `battery_limiter`: despite its name that attribute is the 80% health
+    /// mode below, not a threshold, and counting it here offered a Settings
+    /// switch whose writes had nowhere to go.
     pub battery_limit: bool,
-    /// Battery "Health Mode": the 80% charge cap of the `acer-wmi-battery` WMI
-    /// driver, and only when the firmware actually implements it — the driver
-    /// creates the attribute either way. A separate mechanism from
-    /// `battery_limit`, driven from the Battery page; most machines expose one
-    /// or the other, not both.
+    /// Battery "Health Mode": the firmware's fixed 80% charge cap, driven from
+    /// the Battery page.
+    ///
+    /// One firmware call (`WMID_GUID5` method 21, `HEALTH_MODE`) reachable
+    /// through either driver that exposes it - see
+    /// `battery::health_mode_control`. True only when the firmware really
+    /// implements it, since `acer-wmi-battery` creates its attribute either
+    /// way and reports -1 when it does not.
     pub battery_health: bool,
 }
 
@@ -65,8 +72,8 @@ impl Capabilities {
                 || crate::hardware::magic_rgb::is_logo_available(),
             ec: Path::new("/dev/ec").exists(),
             nvidia_gpu: crate::hardware::nvidia::is_available(),
-            battery_limit: battery_limit_present(),
-            battery_health: wmi_battery_function_supported(battery::WMI_HEALTH_MODE),
+            battery_limit: battery_charge_limit().is_some(),
+            battery_health: health_mode_control().is_some(),
         }
     }
 }
@@ -140,10 +147,9 @@ pub fn wmi_battery_function_supported(relative: &str) -> bool {
         .unwrap_or(false)
 }
 
-fn battery_limit_present() -> bool {
-    // The device number differs across models, so the threshold is discovered
-    // rather than assumed to be on BAT1.
-    battery_charge_limit().is_some() || sysfs(battery::PREDATOR_SENSE_LIMITER).exists()
+/// The health-mode control this machine exposes, whichever driver provides it.
+pub fn health_mode_control() -> Option<PathBuf> {
+    battery::health_mode_control(Path::new(battery::SYSFS_ROOT))
 }
 
 /// Process-wide cached capabilities (detected once on first access).

--- a/predator-sense-gui/src/hardware/extras.rs
+++ b/predator-sense-gui/src/hardware/extras.rs
@@ -1,17 +1,19 @@
-use crate::hardware::capabilities::{battery_charge_limit, sysfs};
+use crate::hardware::capabilities::{battery_charge_limit, health_mode_control};
 use predator_sense_protocol::battery;
 use predator_sense_protocol::helper::{
     Action as HelperAction, BATTERY_LIMIT_DISABLED_PERCENT, BATTERY_LIMIT_ENABLED_PERCENT,
 };
 use std::fs;
 
-/// Battery charge limit (80%) - preserves battery longevity
+/// Adjustable charge threshold (`charge_control_end_threshold`), driven at 80%.
+///
+/// Reads and writes go to the same attribute. An earlier version read the
+/// predator_sense `battery_limiter` here as a first choice while the write
+/// path never touched it, so on a machine that had only that attribute the
+/// switch showed a state it could not change - the write fell through to the
+/// helper, which writes the threshold and has none to write to. That attribute
+/// is the health mode, and lives with the health mode now.
 pub fn get_battery_limiter() -> bool {
-    // Check via sysfs (if available from kernel module)
-    if let Ok(v) = fs::read_to_string(sysfs(battery::PREDATOR_SENSE_LIMITER)) {
-        return v.trim() == "1";
-    }
-    // Fallback: check charge_control_end_threshold
     if let Some(v) = battery_charge_limit().and_then(|path| fs::read_to_string(path).ok()) {
         return v
             .trim()
@@ -23,7 +25,6 @@ pub fn get_battery_limiter() -> bool {
 }
 
 pub fn set_battery_limiter(enabled: bool) -> Result<(), String> {
-    // Try sysfs first
     let threshold = if enabled {
         BATTERY_LIMIT_ENABLED_PERCENT
     } else {
@@ -37,12 +38,14 @@ pub fn set_battery_limiter(enabled: bool) -> Result<(), String> {
     crate::hardware::helper::write_switch(HelperAction::BatteryLimit, enabled)
 }
 
-/// Battery "Health Mode" - a separate WMI mechanism from `set_battery_limiter`
-/// above (some hardware only exposes one or the other). Extracted from what
-/// was inline UI logic in battery_page.rs so the Battery page switch and the
-/// AI assistant's tool dispatcher share one implementation.
+/// Battery "Health Mode" - the firmware's fixed 80% cap, a different mechanism
+/// from the adjustable threshold above.
+///
+/// Reachable through either driver that exposes it: `acer-wmi-battery` calls it
+/// `health_mode`, Linuwu-Sense calls it `battery_limiter`, and both issue the
+/// same `WMID_GUID5` method 21 `HEALTH_MODE` call. Whichever is present is used.
 pub fn get_battery_health_mode() -> bool {
-    if let Ok(v) = fs::read_to_string(sysfs(battery::WMI_HEALTH_MODE)) {
+    if let Some(v) = health_mode_control().and_then(|path| fs::read_to_string(path).ok()) {
         return v.trim() == "1";
     }
     crate::hardware::helper::read_switch(HelperAction::BatteryHealthRead).unwrap_or(false)
@@ -50,9 +53,12 @@ pub fn get_battery_health_mode() -> bool {
 
 pub fn set_battery_health_mode(enabled: bool) -> Result<(), String> {
     let value = predator_sense_protocol::helper::Switch::from(enabled).as_str();
-    // Try sysfs first (works if already root or if udev grants write access).
-    if fs::write(sysfs(battery::WMI_HEALTH_MODE), value).is_ok() {
-        return Ok(());
+    // Try sysfs first (works if already root or if udev grants write access),
+    // on whichever driver exposes the control.
+    if let Some(path) = health_mode_control() {
+        if fs::write(path, value).is_ok() {
+            return Ok(());
+        }
     }
     // Through the registered predator-sense-helper polkit action
     // (auth_admin_keep, cached for a few minutes) rather than an ad-hoc


### PR DESCRIPTION
## Summary

- `predator_sense/battery_limiter` and `acer-wmi-battery/health_mode` are **the same firmware call**, not two mechanisms
- counting the first as a charge *threshold* produced a Settings switch that could not work on machines that have it
- split along what the hardware does: `battery_limit` = adjustable threshold, `battery_health` = the fixed 80% health mode reached through whichever driver exposes it

## They are one command

Linuwu-Sense, `src/linuwu_sense.c`:

```c
static ssize_t predator_battery_limit_store(...) {
    ...
    if (battery_health_set(HEALTH_MODE, val) != AE_OK)
        return -ENODEV;
}
// battery_health_set() → wmi_evaluate_method(WMID_GUID5, 0, 21, &input, &output)
// #define WMID_GUID5 "79772EC5-04B1-4bfd-843C-61E7F77B6CC9"
// #define ACER_WMID_SET_BATTERY_HEALTH_CONTROL_METHODID 21
```

`kernel/acer-wmi-battery.c` in this repo, `set_battery_health_control()`, reaches the same GUID and the same method 21 with the same `HEALTH_MODE` mask. Whichever driver is loaded, the firmware sees one command — the drivers just name the attribute differently.

Probed on a Predator PHN16-73 to confirm the firmware side (read-only, method 20):

```
uFunctionList = 0x03   → only HEALTH_MODE and CALIBRATION_MODE exist
uFunctionStatus[0] = 1 → health mode active
```

No third battery function is advertised, so there is nothing else the "limiter" could have been.

## The switch that could not work

On a machine with Linuwu-Sense and no `charge_control_end_threshold`:

| step | what happened |
|---|---|
| `capabilities.battery_limit` | **true** — `battery_limit_present()` accepted `predator_sense/battery_limiter` |
| Settings | drew the switch |
| `get_battery_limiter()` | read the Linuwu attribute, so the switch showed a state |
| `set_battery_limiter()` | never wrote there — with no threshold it fell through to the helper |
| helper `bat-limit` | writes `battery_threshold(sysfs)?`, which errors when no threshold exists |
| `window.rs` | `let _ = ...` — failure swallowed |

A switch that reads real state, and writes nowhere.

## The split

| | mechanism | drivers |
|---|---|---|
| `battery_limit` | adjustable `charge_control_end_threshold` (a percentage) | generic `power_supply` |
| `battery_health` | fixed 80% health mode (on/off) | `acer-wmi-battery/health_mode` **or** `predator_sense/battery_limiter` |

Backend resolution lives in `battery::health_mode_control()` in the protocol crate, so the GUI, the privileged helper and the boot reapply all agree on which attribute to touch — the same reason battery *paths* were centralised in #28.

An attribute the firmware does not back still does not count: `acer-wmi-battery` creates `health_mode` regardless of support and reports `-1`, and that no longer hides a second driver that does have the function.

## Effect per machine

- **only `acer-wmi-battery`** (the machine this was developed on): unchanged in every respect
- **only Linuwu-Sense**: gains a working control, in the Battery page where the 80% cap belongs, instead of a dead switch in Settings next to a threshold it never was
- **a real `charge_control_end_threshold`**: unchanged; that switch stays in Settings and still writes a percentage
- **both drivers loaded**: one control instead of two that could disagree; the in-tree one is preferred

No config migration is needed: on the machines this changes, the old `battery_limiter` write path never reached hardware, so there is no stored state that meant anything.

## Testing

- `cargo test`: **217** passing (119 GUI / 61 installer / 37 protocol), including new coverage for backend resolution, for the unsupported `-1` attribute, and for the helper and boot reapply reaching the out-of-tree control
- on real hardware, the rebuilt helper resolves this machine's backend and round-trips it: `bat-health-read` → `1`, `bat-health 0` → attribute `0`, `bat-health 1` → attribute `1`
- the firmware probe above was run on this machine to confirm only one battery function exists

**Limitation:** I do not have a machine running Linuwu-Sense. The broken-switch path is established from the code (`battery_limit_present()`, `set_battery_limiter()`, the helper's `battery_threshold()`) and covered by fixtures that stand in for that driver's attribute, not by observing it on such a machine. If someone has one, the check is whether the Battery page switch now moves `predator_sense/battery_limiter`.

## Note

An earlier comment of mine on this topic claimed `Capabilities::battery_charge_cap()` was dead code. That was wrong — it is used by the Dashboard feature chip (`dashboard_page.rs`). Nothing here removes it.
