### PR TITLE
fix: reap spawned processes, and stop the animation timers when nobody is looking

### DIFF
--- a/predator-sense-gui/installer/src/hotkey.rs
+++ b/predator-sense-gui/installer/src/hotkey.rs
@@ -1,5 +1,5 @@
 use crate::constants::{app, command, hardware, logging, path, timing};
-use crate::process::process_running;
+use crate::process::{process_running, spawn_reaped};
 use crate::AppResult;
 use predator_sense_protocol::battery;
 use predator_sense_protocol::helper::Action as HelperAction;
@@ -1023,7 +1023,7 @@ fn activate_app(logger: &mut Logger) {
     .stdout(Stdio::null())
     .stderr(Stdio::null());
     ensure_display(&mut bus);
-    if let Err(error) = bus.spawn() {
+    if let Err(error) = spawn_reaped(&mut bus) {
         logger.error(format!("Falha ao chamar gdbus: {error}"));
     }
 
@@ -1034,7 +1034,7 @@ fn activate_app(logger: &mut Logger) {
             .stdout(Stdio::null())
             .stderr(Stdio::null());
         ensure_display(&mut application);
-        match application.spawn() {
+        match spawn_reaped(&mut application) {
             Ok(_) => logger.info("Aplicação iniciada"),
             Err(error) => logger.error(format!("Falha ao iniciar aplicação: {error}")),
         }

--- a/predator-sense-gui/installer/src/process.rs
+++ b/predator-sense-gui/installer/src/process.rs
@@ -18,6 +18,36 @@ pub(crate) fn command_exists(name: &str) -> bool {
         .any(|dir| dir.join(name).is_file())
 }
 
+/// Spawns a process and reaps it when it exits.
+///
+/// A `Child` dropped without being waited on stays in the process table as a
+/// zombie until its parent exits, and these parents are daemons that run for
+/// the whole session - the hotkey daemon was leaking two per keypress, one for
+/// `gdbus` and one for the application it starts.
+///
+/// The `wait` goes on a thread of its own because the callers are an input loop
+/// and a tray callback, and neither can block: one of the children is a GUI
+/// process that lives for hours.
+///
+/// Not `signal(SIGCHLD, SIG_IGN)`, which would reap everything for free. The
+/// same daemons call `Command::status()` elsewhere - the mode key and the boot
+/// ceiling restore both do - and under `SIG_IGN` that call fails with `ECHILD`
+/// instead of returning the exit status, so every invocation that worked would
+/// be reported as a failed helper.
+pub(crate) fn spawn_reaped(command: &mut Command) -> std::io::Result<u32> {
+    let child = command.spawn()?;
+    let pid = child.id();
+    // A thread that cannot be spawned is not worth failing over: the process is
+    // already running, and all that is lost is the zombie this avoids.
+    let _ = std::thread::Builder::new()
+        .name(format!("reap-{pid}"))
+        .spawn(move || {
+            let mut child = child;
+            let _ = child.wait();
+        });
+    Ok(pid)
+}
+
 pub(crate) fn run<I, S>(name: &str, args: I) -> AppResult
 where
     I: IntoIterator<Item = S>,
@@ -176,6 +206,43 @@ pub(crate) fn copy_dir(source: &Path, destination: &Path) -> AppResult {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// Whether `pid` is a process that has exited and not been collected.
+    fn is_zombie(pid: u32) -> bool {
+        let Ok(stat) = fs::read_to_string(format!("{}/{pid}/stat", path::PROC_DIR)) else {
+            return false;
+        };
+        // The state letter is the field after the parenthesised command name,
+        // which is the only field that can itself contain parentheses.
+        stat.rsplit_once(')')
+            .is_some_and(|(_, rest)| rest.split_whitespace().next() == Some("Z"))
+    }
+
+    #[test]
+    fn a_spawned_process_is_collected_instead_of_staying_in_the_table() {
+        let pids: Vec<u32> = (0..4)
+            .map(|_| {
+                spawn_reaped(Command::new("true").stdout(Stdio::null())).expect("spawn true")
+            })
+            .collect();
+
+        // The reaping is on another thread, so this is where the waiting goes.
+        // Dropping the children instead - which is what leaked two processes
+        // per hotkey press - leaves every one of these a zombie until the
+        // daemon exits, so this loop would run out its deadline.
+        let deadline = std::time::Instant::now() + std::time::Duration::from_secs(5);
+        loop {
+            let left: Vec<u32> = pids.iter().copied().filter(|pid| is_zombie(*pid)).collect();
+            if left.is_empty() {
+                return;
+            }
+            assert!(
+                std::time::Instant::now() < deadline,
+                "still uncollected: {left:?}"
+            );
+            std::thread::sleep(std::time::Duration::from_millis(20));
+        }
+    }
 
     #[test]
     fn executable_matching_does_not_accept_a_shared_name_prefix() {

--- a/predator-sense-gui/installer/src/process.rs
+++ b/predator-sense-gui/installer/src/process.rs
@@ -207,15 +207,14 @@ pub(crate) fn copy_dir(source: &Path, destination: &Path) -> AppResult {
 mod tests {
     use super::*;
 
-    /// Whether `pid` is a process that has exited and not been collected.
-    fn is_zombie(pid: u32) -> bool {
-        let Ok(stat) = fs::read_to_string(format!("{}/{pid}/stat", path::PROC_DIR)) else {
-            return false;
-        };
-        // The state letter is the field after the parenthesised command name,
-        // which is the only field that can itself contain parentheses.
-        stat.rsplit_once(')')
-            .is_some_and(|(_, rest)| rest.split_whitespace().next() == Some("Z"))
+    /// Whether `pid` is still in the process table at all.
+    ///
+    /// Presence, not zombie-ness: a child that has not exited yet is not a
+    /// zombie either, so a test that waited for "no zombies" could pass before
+    /// any of them had finished, and pass just as happily against code that
+    /// never reaps. Gone is the only state that says the collecting happened.
+    fn in_process_table(pid: u32) -> bool {
+        fs::metadata(format!("{}/{pid}", path::PROC_DIR)).is_ok()
     }
 
     #[test]
@@ -227,18 +226,22 @@ mod tests {
             .collect();
 
         // The reaping is on another thread, so this is where the waiting goes.
-        // Dropping the children instead - which is what leaked two processes
-        // per hotkey press - leaves every one of these a zombie until the
-        // daemon exits, so this loop would run out its deadline.
+        // Dropping the children instead, which is what leaked two processes per
+        // hotkey press, leaves every one of these in the table as a zombie until
+        // the daemon exits, so this loop would run out its deadline.
         let deadline = std::time::Instant::now() + std::time::Duration::from_secs(5);
         loop {
-            let left: Vec<u32> = pids.iter().copied().filter(|pid| is_zombie(*pid)).collect();
+            let left: Vec<u32> = pids
+                .iter()
+                .copied()
+                .filter(|pid| in_process_table(*pid))
+                .collect();
             if left.is_empty() {
                 return;
             }
             assert!(
                 std::time::Instant::now() < deadline,
-                "still uncollected: {left:?}"
+                "still in the process table: {left:?}"
             );
             std::thread::sleep(std::time::Duration::from_millis(20));
         }

--- a/predator-sense-gui/installer/src/tray.rs
+++ b/predator-sense-gui/installer/src/tray.rs
@@ -1,6 +1,6 @@
 use crate::constants::{app, command, path, service};
 use crate::i18n::{self, Language, Message};
-use crate::process::{process_running, terminate_process};
+use crate::process::{process_running, spawn_reaped, terminate_process};
 use crate::AppResult;
 use ksni::blocking::TrayMethods;
 use std::fs::{self, File, OpenOptions};
@@ -110,27 +110,31 @@ fn acquire_lock() -> AppResult<Option<File>> {
 }
 
 fn activate_application() {
-    let _ = Command::new(command::GDBUS)
-        .args([
-            "call",
-            "--session",
-            "--dest",
-            app::DBUS_ID,
-            "--object-path",
-            app::DBUS_OBJECT_PATH,
-            "--method",
-            app::DBUS_ACTIVATE_METHOD,
-            "[]",
-        ])
-        .stdin(Stdio::null())
-        .stdout(Stdio::null())
-        .stderr(Stdio::null())
-        .spawn();
-    if !process_running(path::APPLICATION) && Path::new(path::APPLICATION).exists() {
-        let _ = Command::new(path::APPLICATION)
+    // Reaped, not dropped: this daemon lives for the whole session, so every
+    // click on the tray icon would otherwise leave a zombie behind.
+    let _ = spawn_reaped(
+        Command::new(command::GDBUS)
+            .args([
+                "call",
+                "--session",
+                "--dest",
+                app::DBUS_ID,
+                "--object-path",
+                app::DBUS_OBJECT_PATH,
+                "--method",
+                app::DBUS_ACTIVATE_METHOD,
+                "[]",
+            ])
             .stdin(Stdio::null())
             .stdout(Stdio::null())
-            .stderr(Stdio::null())
-            .spawn();
+            .stderr(Stdio::null()),
+    );
+    if !process_running(path::APPLICATION) && Path::new(path::APPLICATION).exists() {
+        let _ = spawn_reaped(
+            Command::new(path::APPLICATION)
+                .stdin(Stdio::null())
+                .stdout(Stdio::null())
+                .stderr(Stdio::null()),
+        );
     }
 }

--- a/predator-sense-gui/src/app_state.rs
+++ b/predator-sense-gui/src/app_state.rs
@@ -1,11 +1,30 @@
 use std::sync::atomic::{AtomicBool, Ordering};
 
 static WINDOW_VISIBLE: AtomicBool = AtomicBool::new(true);
+static WINDOW_SUSPENDED: AtomicBool = AtomicBool::new(false);
 
+/// Whether the window is shown at all, as opposed to sitting in the tray.
 pub fn set_window_visible(v: bool) {
     WINDOW_VISIBLE.store(v, Ordering::Relaxed);
 }
 
+/// Whether the compositor has told us the window is not being looked at:
+/// minimized, fully obscured, or on another workspace.
+///
+/// Tracked separately from the flag above because the two answer different
+/// questions and are set from different places - hiding to the tray is this
+/// app's own doing, being suspended is the compositor's.
+pub fn set_window_suspended(v: bool) {
+    WINDOW_SUSPENDED.store(v, Ordering::Relaxed);
+}
+
+/// Whether the window is actually on screen.
+///
+/// The animation timers ask this before doing anything. Minimizing used to
+/// slip past it: `is_mapped()` stays true on a minimized window - GTK unmaps
+/// nothing, the compositor simply stops asking for frames - so the guards that
+/// exist to skip work while nobody is looking never engaged, and the pages kept
+/// interpolating and queueing redraws sixteen times a second.
 pub fn is_window_visible() -> bool {
-    WINDOW_VISIBLE.load(Ordering::Relaxed)
+    WINDOW_VISIBLE.load(Ordering::Relaxed) && !WINDOW_SUSPENDED.load(Ordering::Relaxed)
 }

--- a/predator-sense-gui/src/hardware/alerts.rs
+++ b/predator-sense-gui/src/hardware/alerts.rs
@@ -57,16 +57,16 @@ fn notify(body: &str) {
     }
     LAST_NOTIFY.store(now, Ordering::Relaxed);
 
-    let _ = Command::new("notify-send")
-        .args([
-            "-u",
-            "critical",
-            "-a",
-            "Predator Sense",
-            crate::i18n::t("temp_alert_title"),
-            body,
-        ])
-        .spawn();
+    // Reaped: the GUI stays open for hours, and a dropped `Child` would leave a
+    // zombie behind for every notification it ever sent.
+    let _ = crate::process::spawn_reaped(Command::new("notify-send").args([
+        "-u",
+        "critical",
+        "-a",
+        "Predator Sense",
+        crate::i18n::t("temp_alert_title"),
+        body,
+    ]));
 }
 
 fn unix_secs() -> u64 {

--- a/predator-sense-gui/src/main.rs
+++ b/predator-sense-gui/src/main.rs
@@ -114,13 +114,13 @@ fn main() {
         // Single instance: if window exists, present it
         if let Some(window) = app.active_window() {
             app_state::set_window_visible(true);
-            // Belt and braces: the compositor is the authority on this and its
-            // own notification, if one is coming, lands right after and wins.
-            // Clearing it here means a compositor that never sends one cannot
-            // leave the animations switched off over a window that is back.
-            app_state::set_window_suspended(false);
             window.set_visible(true);
             window.present();
+            // Ask the compositor rather than assume the window came back:
+            // presenting a minimized window can be declined, and clearing the
+            // flag by hand would resume every animation behind a window still
+            // minimized. A restore that does land arrives as a notification.
+            ui::window::sync_window_suspended(&window);
             // Force a full redraw after the WM finishes mapping the window.
             // GTK4 + Cinnamon sometimes leaves the surface blank when reshowing
             // a window that was hidden via set_visible(false).

--- a/predator-sense-gui/src/main.rs
+++ b/predator-sense-gui/src/main.rs
@@ -114,6 +114,11 @@ fn main() {
         // Single instance: if window exists, present it
         if let Some(window) = app.active_window() {
             app_state::set_window_visible(true);
+            // Belt and braces: the compositor is the authority on this and its
+            // own notification, if one is coming, lands right after and wins.
+            // Clearing it here means a compositor that never sends one cannot
+            // leave the animations switched off over a window that is back.
+            app_state::set_window_suspended(false);
             window.set_visible(true);
             window.present();
             // Force a full redraw after the WM finishes mapping the window.

--- a/predator-sense-gui/src/main.rs
+++ b/predator-sense-gui/src/main.rs
@@ -1,6 +1,7 @@
 mod app_state;
 mod config;
 mod hardware;
+mod process;
 pub mod i18n;
 mod tray;
 mod ui;

--- a/predator-sense-gui/src/process.rs
+++ b/predator-sense-gui/src/process.rs
@@ -1,0 +1,30 @@
+//! Starting other processes without leaving them behind.
+
+use std::process::Command;
+
+/// Spawns a process and reaps it when it exits.
+///
+/// A `Child` dropped without being waited on stays in the process table as a
+/// zombie until its parent exits, and this process is a GUI that stays open for
+/// hours - one per tray start, one per temperature notification.
+///
+/// The `wait` goes on a thread of its own: this is called from the GTK main
+/// thread, which cannot block on a child that outlives the call.
+///
+/// Not `signal(SIGCHLD, SIG_IGN)`, which would reap everything for free but
+/// makes `Command::status()` and `Command::output()` fail with `ECHILD` instead
+/// of returning the exit status - and the helper calls all over this crate
+/// depend on reading it.
+pub fn spawn_reaped(command: &mut Command) -> std::io::Result<u32> {
+    let child = command.spawn()?;
+    let pid = child.id();
+    // A thread that cannot be spawned is not worth failing over: the process is
+    // already running, and all that is lost is the zombie this avoids.
+    let _ = std::thread::Builder::new()
+        .name(format!("reap-{pid}"))
+        .spawn(move || {
+            let mut child = child;
+            let _ = child.wait();
+        });
+    Ok(pid)
+}

--- a/predator-sense-gui/src/tray.rs
+++ b/predator-sense-gui/src/tray.rs
@@ -54,9 +54,12 @@ impl TrayManager {
                 }
             });
         }
-        match command.spawn() {
-            Ok(child) => {
-                eprintln!("[tray] processo Rust iniciado (PID {})", child.id());
+        // Reaped even though the child gets its own session: `setsid` detaches
+        // it from the terminal, not from its parent, so it is still this
+        // process that has to collect the exit status.
+        match crate::process::spawn_reaped(&mut command) {
+            Ok(pid) => {
+                eprintln!("[tray] processo Rust iniciado (PID {pid})");
                 self.started = true;
             }
             Err(error) => eprintln!("[tray] falha ao iniciar: {error}"),

--- a/predator-sense-gui/src/ui/magic_rgb_page.rs
+++ b/predator-sense-gui/src/ui/magic_rgb_page.rs
@@ -319,7 +319,10 @@ fn build_keyboard_section() -> gtk::Box {
                 return gtk::glib::ControlFlow::Break;
             }
             let mut st = state.borrow_mut();
-            if st.effect == KeyboardEffect::Breathing && da.is_mapped() {
+            if st.effect == KeyboardEffect::Breathing
+                && da.is_mapped()
+                && crate::app_state::is_window_visible()
+            {
                 st.anim_phase += 0.05 + (st.speed as f64) * 0.03;
                 da.queue_draw();
             }
@@ -614,7 +617,10 @@ fn build_logo_section() -> gtk::Box {
                 return gtk::glib::ControlFlow::Break;
             }
             let mut st = state.borrow_mut();
-            if st.effect == Some(LogoEffect::Breathing) && st.preview_image.is_mapped() {
+            if st.effect == Some(LogoEffect::Breathing)
+                && st.preview_image.is_mapped()
+                && crate::app_state::is_window_visible()
+            {
                 st.anim_phase += 0.05 + (st.speed as f64) * 0.03;
                 update_logo_preview(&st);
             }

--- a/predator-sense-gui/src/ui/rgb_page.rs
+++ b/predator-sense-gui/src/ui/rgb_page.rs
@@ -330,6 +330,12 @@ fn build_keyboard_panel() -> gtk::Box {
             if da.root().is_none() {
                 return glib::ControlFlow::Break;
             }
+            // Mapped is not the same as on screen: a minimized window keeps its
+            // widgets mapped, so without this the preview animates into a
+            // surface nobody is being shown.
+            if !crate::app_state::is_window_visible() || !da.is_mapped() {
+                return glib::ControlFlow::Continue;
+            }
             let mut st = s.borrow_mut();
             if !st.is_static {
                 let speed_factor = 0.03 + (st.speed as f64) * 0.02;

--- a/predator-sense-gui/src/ui/temperatures_page.rs
+++ b/predator-sense-gui/src/ui/temperatures_page.rs
@@ -55,6 +55,9 @@ pub fn build(sensor_data: &SensorData) -> gtk::Box {
             if area.root().is_none() {
                 return glib::ControlFlow::Break;
             }
+            if !crate::app_state::is_window_visible() || !area.is_mapped() {
+                return glib::ControlFlow::Continue;
+            }
             {
                 let mut p = phase.borrow_mut();
                 *p = (*p + 1) % 4; // 0,1,2,3 then wrap to 0 (all off)

--- a/predator-sense-gui/src/ui/window.rs
+++ b/predator-sense-gui/src/ui/window.rs
@@ -120,8 +120,8 @@ pub fn build(app: &adw::Application) {
         window.connect_notify_local(Some(SUSPENDED_PROPERTY), |window, _| {
             crate::app_state::set_window_suspended(window.property::<bool>(SUSPENDED_PROPERTY));
         });
-        crate::app_state::set_window_suspended(window.property::<bool>(SUSPENDED_PROPERTY));
     }
+    sync_window_suspended(&window);
 
     // Handle ALL close events (native X button, our custom button, Alt+F4, etc.)
     let app_clone = app.clone();
@@ -138,6 +138,21 @@ pub fn build(app: &adw::Application) {
 
     window.present();
     crate::startup_mark("window present called");
+}
+
+/// Reads the compositor's current answer into the shared flag.
+///
+/// Called again after presenting the window, because presenting is a request
+/// and not a guarantee: on Wayland the compositor can decline to restore a
+/// minimized window, and then the property never changes, so no notification
+/// arrives to correct anything. Assuming the window came back would start every
+/// animation up again behind a window that is still minimized, which is the
+/// exact cost the guards exist to avoid.
+pub fn sync_window_suspended(window: &impl IsA<gtk::Window>) {
+    let window = window.as_ref();
+    if window.find_property(SUSPENDED_PROPERTY).is_some() {
+        crate::app_state::set_window_suspended(window.property::<bool>(SUSPENDED_PROPERTY));
+    }
 }
 
 /// Esconde a janela e garante que o tray helper está rodando.

--- a/predator-sense-gui/src/ui/window.rs
+++ b/predator-sense-gui/src/ui/window.rs
@@ -20,6 +20,11 @@ thread_local! {
     static TRAY: RefCell<Option<TrayManager>> = const { RefCell::new(None) };
 }
 
+/// `GtkWindow:suspended`, GTK 4.12 and up: the compositor's own word for
+/// "this window is not being shown", which covers minimized, fully obscured,
+/// and on another workspace.
+const SUSPENDED_PROPERTY: &str = "suspended";
+
 pub fn build(app: &adw::Application) {
     crate::startup_mark("window build start");
     let window = gtk::ApplicationWindow::builder()
@@ -100,6 +105,23 @@ pub fn build(app: &adw::Application) {
         build_with_setup(app, &window, &header);
     }
     crate::startup_mark("window content built");
+
+    // The compositor knows when the window stops being looked at - minimized,
+    // fully covered, on another workspace - and nothing else here does: a
+    // minimized window stays mapped, and its widgets with it, so every guard
+    // written as `is_mapped()` keeps saying yes to a window nobody can see.
+    //
+    // Reached through the property rather than `is_suspended()`, which needs
+    // the crate's `v4_12` feature: raising the compile-time API level surfaces
+    // a dozen unrelated deprecations across this crate, and this way a runtime
+    // GTK older than 4.12 just keeps the previous behaviour instead of
+    // panicking on a property that is not there.
+    if window.find_property(SUSPENDED_PROPERTY).is_some() {
+        window.connect_notify_local(Some(SUSPENDED_PROPERTY), |window, _| {
+            crate::app_state::set_window_suspended(window.property::<bool>(SUSPENDED_PROPERTY));
+        });
+        crate::app_state::set_window_suspended(window.property::<bool>(SUSPENDED_PROPERTY));
+    }
 
     // Handle ALL close events (native X button, our custom button, Alt+F4, etc.)
     let app_clone = app.clone();


### PR DESCRIPTION
## Summary

Two fixes found while investigating idle behaviour on a running install, plus one finding that turned out not to be ours to fix.

## 1. Zombie processes

`predator-sense-hotkey` accumulates defunct children, two per hotkey press:

```
2705 gdbus <defunct>            ppid 1622
2708 predator-sense <defunct>   ppid 1622
```

`activate_app` spawns `gdbus` and the application and drops both `Child` handles. A dropped `Child` does not reap, so the process stays in the table until its parent exits, and the parent here runs for the whole session. Reproduced standalone at five zombies for five dropped spawns, zero for five reaped ones.

Three more places had it: the tray daemon's `activate_application` (one pair per click on the icon), the GUI's tray launcher, and the temperature notifications. `setsid` detaches a child from the terminal, not from its parent, so that one leaks too. `window.rs` is fine, since it `exit(0)`s right after spawning and its child is reparented to init.

`signal(SIGCHLD, SIG_IGN)` would reap everything for free and break the mode key. The same daemons call the helper through `Command::status()`, which under `SIG_IGN` cannot collect a status:

```
status() under SIGCHLD=SIG_IGN -> Err(Os { code: 10, "No child processes" })
```

Every invocation that worked would be logged as a failed helper. So the wait goes on a thread of its own, per child.

Covered by a test that spawns four processes and fails if any is still uncollected. Reverting to a plain `spawn()` makes it fail with their pids.

## 2. Animation timers running behind a minimized window

The pages guard their 16 Hz work with `is_window_visible() && is_mapped()`, and neither half is false when the window is minimized. Hiding to the tray is the only thing that clears the first flag, and GTK unmaps nothing on minimize: the compositor stops asking for frames while every widget stays mapped. From a standalone GTK probe:

```
visible     window.is_mapped=true   child.is_mapped=true   suspended=false
minimized   window.is_mapped=true   child.is_mapped=true   suspended=true
hidden      window.is_mapped=false  child.is_mapped=false
```

So the guards written to skip work while nobody is looking never engaged.

`GtkWindow:suspended` is the compositor's own word for this and covers minimized, fully obscured, and on another workspace. It feeds a second flag that `is_window_visible()` folds in, so all ten call sites keep reading the same way and become correct. The three animations that only checked `is_mapped()` (the two keyboard previews and the temperature gauges) now ask as well.

Measured on the same page and machine, debug build, minimizing through the KWin scripting API:

| state | CPU | ctx switches |
|---|---|---|
| visible | 5.0 % | 31 /s |
| minimized, before | 1.75 % | 18 /s |
| minimized, after | 0.25 % | 5 /s |

Read through the property rather than `is_suspended()`, which needs the crate's `v4_12` feature. Raising the compile-time API level surfaces eleven unrelated deprecation warnings (measured: 0 before, 11 after), and the property means a runtime GTK older than 4.12 keeps the previous behaviour instead of panicking on something that is not there. Reactivating also clears the flag by hand, so a compositor that never sends the notification cannot leave the animations switched off over a window that is back.

## Not fixed: a minimized window does not come back

Found while checking that the guard above could not strand the UI. On Wayland, once the window is minimized, neither the tray icon nor the hotkey restores it. Writing down why, so nobody spends an afternoon on it twice:

* xdg-shell has `set_minimized` and no unset, so a client cannot unminimize itself. `unminimize()` is a no-op here, alone or combined.
* `present()` raises a window only with an xdg-activation token, and without one KWin ignores it. Seven sequences tried (present, unminimize, remap, hide and show across separate main-loop iterations), none restores.
* the toplevel never reports `MINIMIZED` on this backend, only `suspended`, which is also true for a window that is merely covered. Intercepting minimize and hiding to the tray instead is therefore not implementable.
* the token has to come from whoever holds focus. The KDE way is `ProvideXdgActivationToken` on the tray item, which `ksni` 0.3.6 (the current release) does not implement, and the hotkey daemon is not a Wayland client at all.

This is the known shape of the problem for GTK tray apps on KDE Wayland. The real fix is upstream in `ksni`, plus passing the token through in the `Activate` platform data. X11 is unaffected.

## Testing

246 tests pass across the three crates, clippy clean. The timer measurements are from the running app on a PHN16-73 under KDE Wayland. The reaping change in the two daemons is not exercised beyond the helper's own test, since it needs a session and input devices.
