### PR TITLE
feat(fan): persist CoolBoost, fan mode and auto curve across restarts

### DIFF
--- a/predator-sense-gui/installer/src/helper.rs
+++ b/predator-sense-gui/installer/src/helper.rs
@@ -8,11 +8,12 @@ use predator_sense_protocol::battery;
 use predator_sense_protocol::helper::{
     Action as HelperAction, CpuGovernor, EnergyPreference, Switch, OPTIONAL_VALUE_SKIP,
 };
+use predator_sense_protocol::internal;
 use predator_sense_protocol::temp_limit::{self, Bound, Capability};
 use predator_sense_protocol::thermal_profile;
 use serde::Deserialize;
 use std::fs::{self, File, OpenOptions};
-use std::io::{Read, Seek, SeekFrom, Write};
+use std::io::{self, BufRead, Read, Seek, SeekFrom, Write};
 use std::os::fd::AsRawFd;
 use std::os::unix::fs::PermissionsExt;
 use std::path::{Path, PathBuf};
@@ -259,7 +260,53 @@ struct CpuProfileLock {
 
 pub(crate) fn run(args: &[String]) -> AppResult {
     let root = test_root().unwrap_or_else(|| PathBuf::from(path::REAL_SYSFS));
-    run_with_paths(args, &root, Path::new(path::EC_DEVICE))
+    let ec = Path::new(path::EC_DEVICE);
+    if args.first().map(String::as_str) == Some(internal::HELPER_DAEMON_ARGUMENT) {
+        let stdin = io::stdin();
+        let stdout = io::stdout();
+        return run_daemon(&root, ec, stdin.lock(), stdout.lock());
+    }
+    run_with_paths(args, &root, ec)
+}
+
+/// Daemon mode: reads one action line at a time (same wire format as normal
+/// argv, space-separated) until the caller's end of stdin closes, replying to
+/// each with an [`internal::HELPER_DAEMON_OK`]/[`internal::HELPER_DAEMON_ERR`]
+/// marker line. See [`internal::HELPER_DAEMON_ARGUMENT`] for why this exists.
+///
+/// A read action's own value reaches the caller exactly like it does in the
+/// one-shot binary - by printing it to stdout - because here that stdout
+/// *is* the reply stream; the marker line right after it is what tells a
+/// caller where that value ends. Generic over its I/O so tests can drive it
+/// without real pipes.
+fn run_daemon(sysfs: &Path, ec: &Path, input: impl BufRead, mut output: impl Write) -> AppResult {
+    for line in input.lines() {
+        let line = line.map_err(|error| fail(format!("daemon: reading command: {error}")))?;
+        let args: Vec<String> = line.split_whitespace().map(String::from).collect();
+        if args.is_empty() {
+            // A caller never sends a blank line on purpose, but skipping it
+            // costs nothing and keeps a stray newline from tearing the
+            // session down.
+            continue;
+        }
+        let reply = match run_with_paths(&args, sysfs, ec) {
+            Ok(()) => internal::HELPER_DAEMON_OK.to_string(),
+            Err(message) => {
+                let message = message.replace('\n', " ");
+                format!("{} {message}", internal::HELPER_DAEMON_ERR)
+            }
+        };
+        writeln!(output, "{reply}")
+            .map_err(|error| fail(format!("daemon: writing reply: {error}")))?;
+        // Rust buffers stdout in blocks when it is not a terminal, which a
+        // pipe never is - without an explicit flush the caller would block
+        // forever waiting for a reply already sitting in this process's
+        // buffer.
+        output
+            .flush()
+            .map_err(|error| fail(format!("daemon: flushing reply: {error}")))?;
+    }
+    Ok(())
 }
 
 fn test_root() -> Option<PathBuf> {
@@ -2405,5 +2452,52 @@ mod tests {
             read_fan_preset(&ec, fixture.path()).unwrap(),
             Some(FanPreset::Maximum)
         );
+    }
+
+    #[test]
+    fn daemon_applies_each_line_and_replies_with_a_marker() {
+        let fixture = TempDir::new().unwrap();
+        let sysfs = fixture.path().join("sys");
+        write(&sysfs, thermal_profile::SYSFS_INDEX, "0");
+
+        // Two commands in one session, exactly as the auto fan curve would
+        // send one PWM write after another over the same pipe.
+        let input = b"thermal-profile 3\nthermal-profile 5\n".as_slice();
+        let mut output = Vec::new();
+        run_daemon(&sysfs, Path::new("/dev/null"), input, &mut output).unwrap();
+
+        assert_eq!(read(&sysfs, thermal_profile::SYSFS_INDEX), "5");
+        let replies: Vec<&str> = std::str::from_utf8(&output).unwrap().lines().collect();
+        assert_eq!(replies, vec![internal::HELPER_DAEMON_OK, internal::HELPER_DAEMON_OK]);
+    }
+
+    #[test]
+    fn daemon_reports_a_failed_command_and_keeps_the_session_open() {
+        let fixture = TempDir::new().unwrap();
+        let sysfs = fixture.path().join("sys");
+        write(&sysfs, thermal_profile::SYSFS_INDEX, "0");
+
+        // A bad command must not tear the session down: the next good one on
+        // the same connection still has to go through.
+        let input = b"not-a-real-action\nthermal-profile 4\n".as_slice();
+        let mut output = Vec::new();
+        run_daemon(&sysfs, Path::new("/dev/null"), input, &mut output).unwrap();
+
+        assert_eq!(read(&sysfs, thermal_profile::SYSFS_INDEX), "4");
+        let replies: Vec<&str> = std::str::from_utf8(&output).unwrap().lines().collect();
+        assert_eq!(replies.len(), 2);
+        assert!(replies[0].starts_with(internal::HELPER_DAEMON_ERR));
+        assert_eq!(replies[1], internal::HELPER_DAEMON_OK);
+    }
+
+    #[test]
+    fn daemon_ignores_blank_lines() {
+        let input = b"\n\n".as_slice();
+        let mut output = Vec::new();
+
+        let ec = Path::new("/dev/null");
+        run_daemon(ec, ec, input, &mut output).unwrap();
+
+        assert!(output.is_empty());
     }
 }

--- a/predator-sense-gui/protocol/src/lib.rs
+++ b/predator-sense-gui/protocol/src/lib.rs
@@ -33,6 +33,27 @@ pub mod internal {
     pub const TRAY_ARGUMENT: &str = "--internal-tray";
     pub const DELAYED_APPLICATION_START_ARGUMENT: &str = "--internal-delayed-start";
     pub const APPLICATION_RESTART_DELAY_MS: u64 = 500;
+
+    /// Puts the privileged helper into daemon mode: instead of running one
+    /// action and exiting, it reads one action line at a time from stdin
+    /// (same wire format as its normal argv) until stdin closes, replying to
+    /// each with [`HELPER_DAEMON_OK`] or [`HELPER_DAEMON_ERR`] on stdout.
+    ///
+    /// This is what lets a caller pay for `pkexec`'s PAM/polkit session once
+    /// and reuse the same privileged process for many writes - the auto fan
+    /// curve was re-authenticating and spawning a new helper process for
+    /// every single PWM write, tens of thousands of times over a session
+    /// (issue #47). The daemon exits on its own once the caller's end of the
+    /// pipe closes, so nothing has to explicitly tear it down.
+    pub const HELPER_DAEMON_ARGUMENT: &str = "--daemon";
+    /// Marks the end of a successful daemon reply. Never a value any action
+    /// prints for itself (those are plain numbers or fixed enum words), so a
+    /// caller can tell reply framing from output on the same stream.
+    pub const HELPER_DAEMON_OK: &str = "__predator_sense_helper_ok__";
+    /// Marks the end of a failed daemon reply; the rest of the line is the
+    /// error message, with any newlines in it collapsed to spaces so the
+    /// reply still fits on one line.
+    pub const HELPER_DAEMON_ERR: &str = "__predator_sense_helper_err__";
 }
 
 pub mod installer {

--- a/predator-sense-gui/src/config.rs
+++ b/predator-sense-gui/src/config.rs
@@ -114,6 +114,23 @@ pub struct AppConfig {
     /// existing safety-first behavior for everyone who doesn't touch it.
     #[serde(default)]
     pub keep_fan_auto_in_performance: bool,
+    /// Fan Control page (`ui::fan_control_page`): CoolBoost and the selected
+    /// fan mode used to only ever be written straight to the EC, with
+    /// nothing remembering the user's choice - so closing Predator Sense (or
+    /// a reboot resetting the EC) silently dropped them back to the
+    /// hardware default, with no way for the app to notice and turn them
+    /// back on. Reapplied by `build_main_ui` on every start.
+    #[serde(default)]
+    pub coolboost_enabled: bool,
+    /// "auto" or "max" - the last fan mode explicitly chosen on that page.
+    /// None means never touched, so startup leaves the firmware alone.
+    /// Custom PWM is intentionally excluded, same as `fan::set_fan_mode`.
+    #[serde(default)]
+    pub fan_mode: Option<String>,
+    /// Same "forgot on close" gap for the page's software auto-curve switch,
+    /// which used to live only in that page's local, in-memory state.
+    #[serde(default)]
+    pub fan_auto_curve_enabled: bool,
     /// Last-applied static RGB zone colors (issue #11: nothing persisted this
     /// before, so a full power cycle always reset the keyboard to its default
     /// pulsing effect). Reapplied after login/resume by the Rust hotkey service.
@@ -240,6 +257,9 @@ impl Default for AppConfig {
             font_scale: 1.0,
             debug_logging: false,
             keep_fan_auto_in_performance: false,
+            coolboost_enabled: false,
+            fan_mode: None,
+            fan_auto_curve_enabled: false,
             rgb_static_zones: None,
             rgb_brightness: 100,
             rgb_is_static: true,

--- a/predator-sense-gui/src/hardware/fan.rs
+++ b/predator-sense-gui/src/hardware/fan.rs
@@ -76,6 +76,19 @@ pub fn set_pwm_auto() -> Result<(), String> {
     Ok(())
 }
 
+/// Simple CPU-temperature to fan-speed curve (percent) for the software
+/// auto-curve toggle on the Fan Control page.
+pub fn fan_curve_pct(temp_c: f64) -> u8 {
+    match temp_c {
+        t if t < 45.0 => 25,
+        t if t < 55.0 => 35,
+        t if t < 65.0 => 50,
+        t if t < 75.0 => 65,
+        t if t < 85.0 => 80,
+        _ => 100,
+    }
+}
+
 /// Read current CPU/GPU fan PWM as percentage (0-100), if available.
 pub fn get_pwm_percent() -> Option<(u8, u8)> {
     let cpu: u16 = crate::hardware::helper::read(HelperAction::PwmCpuRead)?

--- a/predator-sense-gui/src/hardware/helper.rs
+++ b/predator-sense-gui/src/hardware/helper.rs
@@ -1,16 +1,22 @@
 use predator_sense_protocol::helper::{Action, Switch};
-use predator_sense_protocol::path;
-use std::process::{Command, Output};
+use predator_sense_protocol::{internal, path};
+use std::io::{BufRead, BufReader, Write};
+use std::process::{Child, ChildStdin, ChildStdout, Command, Output, Stdio};
+use std::sync::Mutex;
 
 const PRIVILEGE_BROKER: &str = "pkexec";
 const DISABLED_EC_BYTE: u8 = 0;
 
 pub fn execute(action: Action, arguments: &[&str]) -> Result<(), String> {
-    let output = invoke(action, arguments)?;
-    if output.status.success() {
+    let reply = invoke_session(action, arguments)?;
+    if reply.success {
         Ok(())
     } else {
-        Err(output_error(action, &output))
+        Err(format!(
+            "Hardware helper action '{}' failed: {}",
+            action.as_str(),
+            reply.detail
+        ))
     }
 }
 
@@ -51,8 +57,16 @@ const PKEXEC_LAUNCH_FAILED: i32 = 127;
 const PKEXEC_NOT_AUTHORIZED: i32 = 126;
 
 /// Like [`execute`], but says whether the hardware was ever reached.
+///
+/// Deliberately goes through [`invoke_oneshot`] rather than the persistent
+/// session `execute` uses: this is what lets it read `pkexec`'s own exit code
+/// below, which the [`NotAuthorized`](Failure::NotAuthorized)/
+/// [`Rejected`](Failure::Rejected) distinction depends on, and it is only
+/// called for calibration - a user-initiated, infrequent action - so there is
+/// no per-call `pkexec` overhead worth amortizing here the way there is for
+/// the auto fan curve's per-tick writes.
 pub fn execute_checked(action: Action, arguments: &[&str]) -> Result<(), Failure> {
-    let output = invoke(action, arguments).map_err(Failure::NotAuthorized)?;
+    let output = invoke_oneshot(action, arguments).map_err(Failure::NotAuthorized)?;
     if output.status.success() {
         return Ok(());
     }
@@ -79,20 +93,18 @@ pub fn read(action: Action) -> Option<String> {
         .then(|| String::from_utf8_lossy(&output.stdout).trim().to_string())
 }
 
-/// Like `read`, but goes through `invoke` (pkexec-elevated when not already
-/// root) instead of calling the helper unprivileged. `read` works for every
-/// other read action because their underlying sysfs paths get their
-/// permissions relaxed by the installer; a few kernel-owned paths (like the
-/// DMI serial number, 0400 root-only by design) never do, and need this.
+/// Like `read`, but goes through the persistent session (pkexec-elevated
+/// when not already root) instead of calling the helper unprivileged. `read`
+/// works for every other read action because their underlying sysfs paths
+/// get their permissions relaxed by the installer; a few kernel-owned paths
+/// (like the DMI serial number, 0400 root-only by design) never do, and need
+/// this.
 pub fn read_privileged(action: Action) -> Option<String> {
     if action.argument_count() != 0 {
         return None;
     }
-    let output = invoke(action, &[]).ok()?;
-    output
-        .status
-        .success()
-        .then(|| String::from_utf8_lossy(&output.stdout).trim().to_string())
+    let reply = invoke_session(action, &[]).ok()?;
+    reply.success.then_some(reply.stdout)
 }
 
 pub fn read_switch(action: Action) -> Option<bool> {
@@ -120,7 +132,11 @@ pub fn write_switch(action: Action, enabled: bool) -> Result<(), String> {
     execute(action, &[Switch::from(enabled).as_str()])
 }
 
-fn invoke(action: Action, arguments: &[&str]) -> Result<Output, String> {
+/// One-shot invocation: a fresh `pkexec` (or a direct call when already
+/// root) for this action alone. What every privileged call used before the
+/// persistent session existed, and still what [`execute_checked`] uses - see
+/// its doc comment for why.
+fn invoke_oneshot(action: Action, arguments: &[&str]) -> Result<Output, String> {
     validate_arity(action, arguments)?;
     // SAFETY: geteuid has no preconditions.
     let mut command = if unsafe { libc::geteuid() } == 0 {
@@ -135,6 +151,175 @@ fn invoke(action: Action, arguments: &[&str]) -> Result<Output, String> {
         .args(arguments)
         .output()
         .map_err(|error| format!("Failed to launch hardware helper: {error}"))
+}
+
+/// Result of a privileged call, in either mode - a real [`Output`] for the
+/// one-shot path, or a daemon reply line pair for the session path. Neither
+/// carries a process exit code the way [`Output`] does for the one-shot
+/// path, so callers that only need to know "did it work" and "what did it
+/// say" use this instead of `Output` directly.
+struct Reply {
+    success: bool,
+    /// Whatever a read action printed (empty for a write action).
+    stdout: String,
+    /// Diagnostic text for a failure - what went wrong, not a full render of
+    /// stdout/stderr.
+    detail: String,
+}
+
+impl Reply {
+    fn from_output(output: &Output) -> Self {
+        Self {
+            success: output.status.success(),
+            stdout: String::from_utf8_lossy(&output.stdout).trim().to_string(),
+            detail: {
+                let stderr = String::from_utf8_lossy(&output.stderr);
+                let stdout = String::from_utf8_lossy(&output.stdout);
+                let detail = if stderr.trim().is_empty() {
+                    stdout.trim()
+                } else {
+                    stderr.trim()
+                };
+                if detail.is_empty() {
+                    "no diagnostic output".to_string()
+                } else {
+                    detail.to_string()
+                }
+            },
+        }
+    }
+}
+
+/// A running `--daemon` helper, talked to over its own stdin/stdout pipes.
+///
+/// Generic over its I/O so the wire framing (`call`) can be tested against
+/// an in-memory buffer instead of a real child process.
+struct Session<W, R> {
+    stdin: W,
+    stdout: R,
+}
+
+/// The pipe closed or errored mid-call: the daemon died - authorization was
+/// refused, it crashed, or the caller closed its end - and this call went
+/// unanswered. Never means "the action failed"; that is [`Reply::success`].
+#[derive(Debug)]
+struct SessionBroken;
+
+impl<W: Write, R: BufRead> Session<W, R> {
+    fn call(&mut self, action: Action, arguments: &[&str]) -> Result<Reply, SessionBroken> {
+        let mut command_line = action.as_str().to_string();
+        for argument in arguments {
+            command_line.push(' ');
+            command_line.push_str(argument);
+        }
+        command_line.push('\n');
+        self.stdin
+            .write_all(command_line.as_bytes())
+            .and_then(|()| self.stdin.flush())
+            .map_err(|_| SessionBroken)?;
+
+        // A read action's value reaches this stream exactly like it does in
+        // one-shot mode - printed straight to stdout - so everything up to
+        // the marker line is that value, and the marker is how the daemon
+        // tells us where it ends. See `internal::HELPER_DAEMON_ARGUMENT`.
+        let error_prefix = format!("{} ", internal::HELPER_DAEMON_ERR);
+        let mut printed = Vec::new();
+        loop {
+            let mut line = String::new();
+            let read = self.stdout.read_line(&mut line).map_err(|_| SessionBroken)?;
+            if read == 0 {
+                return Err(SessionBroken);
+            }
+            let line = line.trim_end_matches(['\n', '\r']);
+            if let Some(detail) = line.strip_prefix(&error_prefix) {
+                return Ok(Reply {
+                    success: false,
+                    stdout: printed.join("\n"),
+                    detail: detail.to_string(),
+                });
+            }
+            if line == internal::HELPER_DAEMON_OK {
+                return Ok(Reply {
+                    success: true,
+                    stdout: printed.join("\n"),
+                    detail: String::new(),
+                });
+            }
+            printed.push(line.to_string());
+        }
+    }
+}
+
+type RealSession = Session<ChildStdin, BufReader<ChildStdout>>;
+
+/// The persistent helper, once one has been started. `None` before the first
+/// privileged call, and again after any call finds the pipe broken.
+///
+/// One session for the whole process rather than one per caller: every
+/// privileged write ultimately goes through the same root process, which is
+/// the entire point - see `internal::HELPER_DAEMON_ARGUMENT`. The mutex also
+/// serializes calls, which a single pair of pipes requires anyway (two
+/// commands in flight at once would interleave on the wire).
+static SESSION: Mutex<Option<(Child, RealSession)>> = Mutex::new(None);
+
+fn spawn_session() -> Result<(Child, RealSession), String> {
+    let mut child = Command::new(PRIVILEGE_BROKER)
+        .arg(path::HELPER)
+        .arg(internal::HELPER_DAEMON_ARGUMENT)
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::null())
+        .spawn()
+        .map_err(|error| format!("Failed to launch hardware helper: {error}"))?;
+    let stdin = child.stdin.take().expect("piped stdin");
+    let stdout = BufReader::new(child.stdout.take().expect("piped stdout"));
+    Ok((child, Session { stdin, stdout }))
+}
+
+/// Like [`invoke_oneshot`], but reuses one long-lived privileged helper
+/// across calls instead of paying for a fresh `pkexec` authorization and
+/// process spawn every time. See `internal::HELPER_DAEMON_ARGUMENT`.
+fn invoke_session(action: Action, arguments: &[&str]) -> Result<Reply, String> {
+    validate_arity(action, arguments)?;
+    // SAFETY: geteuid has no preconditions.
+    if unsafe { libc::geteuid() } == 0 {
+        // Already root: no broker, and nothing to amortize by keeping a
+        // second process around.
+        let output = Command::new(path::HELPER)
+            .arg(action.as_str())
+            .args(arguments)
+            .output()
+            .map_err(|error| format!("Failed to launch hardware helper: {error}"))?;
+        return Ok(Reply::from_output(&output));
+    }
+
+    let mut guard = SESSION.lock().unwrap_or_else(|poisoned| poisoned.into_inner());
+    if guard.is_none() {
+        *guard = Some(spawn_session()?);
+    }
+    let (_, session) = guard.as_mut().expect("just populated above");
+    match session.call(action, arguments) {
+        Ok(reply) => Ok(reply),
+        Err(SessionBroken) => {
+            // The session is dead - authorization refused, or the process
+            // crashed. Reap it (the pipe closing means it is exiting, if it
+            // has not already) instead of leaving a zombie around until this
+            // process itself exits, then pay for exactly one more `pkexec`
+            // prompt before giving up, rather than leaving every future call
+            // failing forever because of a session that will never recover
+            // on its own.
+            if let Some((mut dead_child, _)) = guard.take() {
+                let _ = dead_child.wait();
+            }
+            let (child, mut session) = spawn_session()?;
+            let reply = session.call(action, arguments).map_err(|SessionBroken| {
+                "Hardware helper daemon closed the connection immediately after starting"
+                    .to_string()
+            })?;
+            *guard = Some((child, session));
+            Ok(reply)
+        }
+    }
 }
 
 fn validate_arity(action: Action, arguments: &[&str]) -> Result<(), String> {
@@ -171,6 +356,7 @@ fn output_error(action: Action, output: &Output) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::io::Cursor;
 
     #[test]
     fn rejects_wrong_argument_count_before_spawning_a_process() {
@@ -187,5 +373,51 @@ mod tests {
         assert_eq!(parse_nonzero_byte("2"), Some(true));
         assert_eq!(parse_nonzero_byte("255"), Some(true));
         assert_eq!(parse_nonzero_byte("invalid"), None);
+    }
+
+    fn session_with_reply(reply: &str) -> Session<Vec<u8>, Cursor<Vec<u8>>> {
+        Session {
+            stdin: Vec::new(),
+            stdout: Cursor::new(reply.as_bytes().to_vec()),
+        }
+    }
+
+    #[test]
+    fn session_call_encodes_the_action_and_arguments_as_one_line() {
+        let mut session = session_with_reply("__predator_sense_helper_ok__\n");
+
+        session.call(Action::PwmCpu, &["120"]).unwrap();
+
+        assert_eq!(session.stdin, b"pwm-cpu 120\n");
+    }
+
+    #[test]
+    fn session_call_reads_a_printed_value_before_the_ok_marker() {
+        let mut session = session_with_reply("42\n__predator_sense_helper_ok__\n");
+
+        let reply = session.call(Action::PwmCpuRead, &[]).unwrap();
+
+        assert!(reply.success);
+        assert_eq!(reply.stdout, "42");
+    }
+
+    #[test]
+    fn session_call_reports_the_error_message_on_a_failed_reply() {
+        let mut session =
+            session_with_reply("__predator_sense_helper_err__ predator-sense-helper: boom\n");
+
+        let reply = session.call(Action::PwmCpu, &["1"]).unwrap();
+
+        assert!(!reply.success);
+        assert_eq!(reply.detail, "predator-sense-helper: boom");
+    }
+
+    #[test]
+    fn session_call_treats_a_closed_pipe_as_broken() {
+        // The daemon exited without ever answering - authorization refused,
+        // or it crashed before replying.
+        let mut session = session_with_reply("");
+
+        assert!(session.call(Action::PwmCpu, &["1"]).is_err());
     }
 }

--- a/predator-sense-gui/src/ui/fan_control_page.rs
+++ b/predator-sense-gui/src/ui/fan_control_page.rs
@@ -4,6 +4,7 @@ use std::cell::{Cell, RefCell};
 use std::f64::consts::PI;
 use std::rc::Rc;
 
+use crate::config;
 use crate::hardware::{fan, sensors};
 use crate::ui::background;
 
@@ -15,6 +16,7 @@ pub fn build() -> gtk::Box {
     page.set_margin_end(20);
 
     let caps = crate::hardware::capabilities::get();
+    let cfg = config::load_app_config();
 
     // Header — CoolBoost only where EC access (/dev/ec) is available.
     let top = gtk::Box::new(gtk::Orientation::Horizontal, 12);
@@ -186,6 +188,9 @@ pub fn build() -> gtk::Box {
 
             match fan::set_fan_mode(fan_mode) {
                 Ok(()) => {
+                    let mut c = config::load_app_config();
+                    c.fan_mode = Some(mode.clone());
+                    let _ = config::save_app_config(&c);
                     let msg = match mode.as_str() {
                         "auto" => crate::i18n::t("automatic"),
                         "max" => crate::i18n::t("max"),
@@ -235,6 +240,9 @@ pub fn build() -> gtk::Box {
                 coolboost.set_active(coolboost_enabled);
                 coolboost.connect_state_set(move |_, enabled| {
                     let _ = fan::set_coolboost(enabled);
+                    let mut c = config::load_app_config();
+                    c.coolboost_enabled = enabled;
+                    let _ = config::save_app_config(&c);
                     glib::Propagation::Proceed
                 });
                 coolboost.set_sensitive(true);
@@ -333,29 +341,21 @@ pub fn build() -> gtk::Box {
         curve_lbl.add_css_class("control-label");
         let curve_switch = gtk::Switch::new();
         curve_switch.set_valign(gtk::Align::Center);
+        curve_switch.set_active(cfg.fan_auto_curve_enabled);
         curve_box.append(&curve_lbl);
         curve_box.append(&curve_switch);
         page.append(&curve_box);
 
-        let curve_on = Rc::new(RefCell::new(false));
-        {
-            let on = curve_on.clone();
-            curve_switch.connect_state_set(move |_, active| {
-                *on.borrow_mut() = active;
-                glib::Propagation::Proceed
-            });
-        }
-        // Apply curve every 3s while enabled.
-        let on = curve_on.clone();
-        glib::timeout_add_seconds_local(3, move || {
-            if *on.borrow() {
-                let (cpu, _gpu) = sensors::read_critical_temps();
-                if let Some(t) = cpu {
-                    let pct = fan_curve_pct(t);
-                    let _ = fan::set_pwm_percent(pct, pct);
-                }
-            }
-            glib::ControlFlow::Continue
+        // Only persists the choice here - enforcement runs in a global timer
+        // (`build_main_ui` in window.rs) instead of one local to this page,
+        // because pages in this app are built lazily on first navigation, so
+        // a page-local timer would never bring the curve back on a fresh
+        // launch until the user visited Fan Control again.
+        curve_switch.connect_state_set(move |_, active| {
+            let mut c = config::load_app_config();
+            c.fan_auto_curve_enabled = active;
+            let _ = config::save_app_config(&c);
+            glib::Propagation::Proceed
         });
     } else {
         // No per-fan PWM: explain (no error) that only firmware modes exist.
@@ -531,16 +531,4 @@ fn draw_animated_fan(cr: &gtk4::cairo::Context, w: f64, h: f64, rotation: f64, r
     let ext3 = cr.text_extents(&t).unwrap();
     cr.move_to(cx - ext3.width() / 2.0, cy + outer_r + 16.0);
     let _ = cr.show_text(&t);
-}
-
-/// Simple CPU-temperature to fan-speed curve (percent) for the auto mode.
-fn fan_curve_pct(temp_c: f64) -> u8 {
-    match temp_c {
-        t if t < 45.0 => 25,
-        t if t < 55.0 => 35,
-        t if t < 65.0 => 50,
-        t if t < 75.0 => 65,
-        t if t < 85.0 => 80,
-        _ => 100,
-    }
 }

--- a/predator-sense-gui/src/ui/window.rs
+++ b/predator-sense-gui/src/ui/window.rs
@@ -216,6 +216,39 @@ fn build_main_ui(app: &adw::Application, window: &gtk::ApplicationWindow) {
             cfg.keep_fan_auto_in_performance,
         );
         crate::hardware::game_sync::set_enabled(cfg.game_sync_enabled);
+
+        // Fan Control page (ui::fan_control_page): CoolBoost and fan mode
+        // used to only ever be written straight to the EC with nothing
+        // remembering the choice, so closing Predator Sense (or a reboot
+        // resetting the EC) silently dropped them - reapply them here on
+        // every start. Off the GTK thread since each helper write costs
+        // roughly 150ms and can trigger a polkit prompt.
+        let coolboost_enabled = cfg.coolboost_enabled;
+        let fan_mode = cfg.fan_mode.clone();
+        if crate::hardware::capabilities::get().ec && (coolboost_enabled || fan_mode.is_some()) {
+            background::run(
+                move || {
+                    if coolboost_enabled {
+                        let _ = crate::hardware::fan::set_coolboost(true);
+                    }
+                    match fan_mode.as_deref() {
+                        Some("max") => {
+                            let _ = crate::hardware::fan::set_fan_mode(
+                                crate::hardware::fan::FanMode::Max,
+                            );
+                        }
+                        Some("auto") => {
+                            let _ = crate::hardware::fan::set_fan_mode(
+                                crate::hardware::fan::FanMode::Auto,
+                            );
+                        }
+                        _ => {}
+                    }
+                },
+                |()| {},
+            );
+        }
+
         glib::timeout_add_seconds_local(5, || {
             let (cpu, gpu) = sensors::read_critical_temps();
             crate::hardware::alerts::check(cpu, gpu);
@@ -227,6 +260,26 @@ fn build_main_ui(app: &adw::Application, window: &gtk::ApplicationWindow) {
             crate::hardware::game_sync::check(&config::load_app_config().game_profiles);
             glib::ControlFlow::Continue
         });
+
+        // Software auto fan-curve (fan_control_page.rs "fan_auto_curve"
+        // switch): runs globally rather than only while that page is open,
+        // since pages here are built lazily on first navigation - a
+        // page-local timer would never restart the curve after a fresh
+        // launch until the user visited Fan Control again. Re-reads the
+        // config every tick, same as the game list above: toggling the
+        // switch takes effect on the next tick, no restart needed.
+        if crate::hardware::capabilities::get().fan_pwm {
+            glib::timeout_add_seconds_local(3, || {
+                if config::load_app_config().fan_auto_curve_enabled {
+                    let (cpu, _gpu) = sensors::read_critical_temps();
+                    if let Some(t) = cpu {
+                        let pct = crate::hardware::fan::fan_curve_pct(t);
+                        let _ = crate::hardware::fan::set_pwm_percent(pct, pct);
+                    }
+                }
+                glib::ControlFlow::Continue
+            });
+        }
     }
 
     // AI assistant background monitor (opt-in, off unless ai_assistant_enabled).


### PR DESCRIPTION
## Summary
- CoolBoost, the Auto/Max fan mode button, and the software auto-curve switch on the Fan Control page only wrote straight to the EC or to a page-local in-memory flag, so closing Predator Sense (or a reboot resetting the EC) silently dropped them back to the hardware default
- Persists all three in `config.json` and reapplies them from `build_main_ui` on every start: CoolBoost/fan mode through the helper (off the GTK thread), and the auto curve through a global timer that re-reads the setting every tick, since pages are built lazily on first navigation and a page-local timer would never restart the curve until the user revisited Fan Control
- Builds on top of #48 (persistent privileged helper for the auto curve), since this PR makes that curve-enforcement loop run continuously from app start rather than only while the Fan Control page is open - the diff will look cleaner once #48 merges into main

## Test plan
- [x] `cargo build` (clean, no new warnings)
- [x] `cargo test` (149 passed)
- [ ] Manual: enable CoolBoost / Auto mode / Auto Curve, fully quit Predator Sense, relaunch, confirm all three are still applied without revisiting Fan Control

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JZa8kSMcBbpA28TVnx5JEj
