### PR TITLE
Add openSUSE in readme; minor chage on install.rs

### DIFF
--- a/README-de.md
+++ b/README-de.md
@@ -253,7 +253,7 @@ sudo ./predator-sense-installer
 
 Wählen Sie **Option 1** (vollständige Installation). Der Installer wird automatisch:
 
-1. Ihre Distribution erkennen (Debian/Ubuntu/Mint, Fedora, Arch)
+1. Ihre Distribution erkennen (Debian/Ubuntu/Mint, Fedora, Arch, openSUSE)
 2. Systemabhängigkeiten installieren (GTK4, libadwaita, Build-Tools, Kernel-Header)
 3. Quellcode und vorkompilierte Binärdatei des passenden Releases herunterladen
 4. Das Kernelmodul `facer` kompilieren und laden (dieser Teil wird immer lokal kompiliert; Kernelmodule können nicht über verschiedene Kernel-Versionen hinweg vorkompiliert ausgeliefert werden)
@@ -295,6 +295,14 @@ sudo dnf install gtk4-devel libadwaita-devel pkg-config gcc make \
 
 ```console
 sudo pacman -S gtk4 libadwaita pkgconf gcc make dkms curl tar linux-headers
+```
+</details>
+
+<details>
+<summary><b>openSUSE</b></summary>
+
+```console
+sudo zypper in gtk4-devel libadwaita-devel pkgconf-pkg-config gcc make dkms curl tar sudo
 ```
 </details>
 

--- a/README-es.md
+++ b/README-es.md
@@ -253,7 +253,7 @@ sudo ./predator-sense-installer
 
 Selecciona la **opción 1** (Instalación Completa). El instalador automáticamente:
 
-1. Detecta tu distribución (Debian/Ubuntu/Mint, Fedora, Arch)
+1. Detecta tu distribución (Debian/Ubuntu/Mint, Fedora, Arch, openSUSE)
 2. Instala las dependencias del sistema (GTK4, libadwaita, herramientas de compilación, headers del kernel)
 3. Descarga el código fuente + binario precompilado de la release correspondiente
 4. Compila y carga el módulo del kernel `facer` (esta parte siempre se compila localmente — los módulos del kernel no se pueden distribuir precompilados entre distintas versiones del kernel)
@@ -295,6 +295,14 @@ sudo dnf install gtk4-devel libadwaita-devel pkg-config gcc make \
 
 ```console
 sudo pacman -S gtk4 libadwaita pkgconf gcc make dkms curl tar linux-headers
+```
+</details>
+
+<details>
+<summary><b>openSUSE</b></summary>
+
+```console
+sudo zypper in gtk4-devel libadwaita-devel pkgconf-pkg-config gcc make dkms curl tar sudo
 ```
 </details>
 

--- a/README-it.md
+++ b/README-it.md
@@ -253,7 +253,7 @@ sudo ./predator-sense-installer
 
 Seleziona l'**opzione 1** (Installazione completa). L'installer eseguirà automaticamente:
 
-1. Rileva la tua distribuzione (Debian/Ubuntu/Mint, Fedora, Arch)
+1. Rileva la tua distribuzione (Debian/Ubuntu/Mint, Fedora, Arch, openSUSE)
 2. Installa le dipendenze di sistema (GTK4, libadwaita, strumenti di build, header del kernel)
 3. Scarica il codice sorgente + binario precompilato della release corrispondente
 4. Compila e carica il modulo kernel `facer` (questa parte compila sempre localmente — i moduli kernel non possono essere distribuiti precompilati tra versioni diverse del kernel)
@@ -295,6 +295,14 @@ sudo dnf install gtk4-devel libadwaita-devel pkg-config gcc make \
 
 ```console
 sudo pacman -S gtk4 libadwaita pkgconf gcc make dkms curl tar linux-headers
+```
+</details>
+
+<details>
+<summary><b>openSUSE</b></summary>
+
+```console
+sudo zypper in gtk4-devel libadwaita-devel pkgconf-pkg-config gcc make dkms curl tar sudo
 ```
 </details>
 

--- a/README-ja.md
+++ b/README-ja.md
@@ -253,7 +253,7 @@ sudo ./predator-sense-installer
 
 **オプション1**（完全インストール）を選択してください。インストーラーは自動的に以下を行います。
 
-1. ディストリビューションを検出（Debian/Ubuntu/Mint、Fedora、Arch）
+1. ディストリビューションを検出（Debian/Ubuntu/Mint、Fedora、Arch、openSUSE）
 2. システムの依存関係をインストール（GTK4、libadwaita、ビルドツール、カーネルヘッダー）
 3. 対応するリリースのソースコード + ビルド済みバイナリをダウンロード
 4. `facer`カーネルモジュールをコンパイルして読み込み（この部分は常にローカルでコンパイルされます — カーネルモジュールは異なるカーネルバージョン間でビルド済みとして配布できないためです）
@@ -295,6 +295,14 @@ sudo dnf install gtk4-devel libadwaita-devel pkg-config gcc make \
 
 ```console
 sudo pacman -S gtk4 libadwaita pkgconf gcc make dkms curl tar linux-headers
+```
+</details>
+
+<details>
+<summary><b>openSUSE</b></summary>
+
+```console
+sudo zypper in gtk4-devel libadwaita-devel pkgconf-pkg-config gcc make dkms curl tar sudo
 ```
 </details>
 

--- a/README-ptbr.md
+++ b/README-ptbr.md
@@ -253,7 +253,7 @@ sudo ./predator-sense-installer
 
 Selecione a **opção 1** (Instalação completa). O instalador irá automaticamente:
 
-1. Detectar sua distribuição (Debian/Ubuntu/Mint, Fedora, Arch)
+1. Detectar sua distribuição (Debian/Ubuntu/Mint, Fedora, Arch, openSUSE)
 2. Instalar dependências do sistema (GTK4, libadwaita, ferramentas de compilação, headers do kernel)
 3. Baixar o código fonte + binário pré-compilado da release correspondente
 4. Compilar e carregar o módulo do kernel `facer` (essa parte sempre compila localmente — módulo de kernel não dá pra distribuir pré-compilado entre versões de kernel diferentes)
@@ -295,6 +295,14 @@ sudo dnf install gtk4-devel libadwaita-devel pkg-config gcc make \
 
 ```console
 sudo pacman -S gtk4 libadwaita pkgconf gcc make dkms curl tar linux-headers
+```
+</details>
+
+<details>
+<summary><b>openSUSE</b></summary>
+
+```console
+sudo zypper in gtk4-devel libadwaita-devel pkgconf-pkg-config gcc make dkms curl tar sudo
 ```
 </details>
 

--- a/README-ru.md
+++ b/README-ru.md
@@ -253,7 +253,7 @@ sudo ./predator-sense-installer
 
 Выберите **опцию 1** (Полная установка). Установщик автоматически:
 
-1. Определит ваш дистрибутив (Debian/Ubuntu/Mint, Fedora, Arch)
+1. Определит ваш дистрибутив (Debian/Ubuntu/Mint, Fedora, Arch, openSUSE)
 2. Установит системные зависимости (GTK4, libadwaita, инструменты сборки, заголовки ядра)
 3. Скачает исходный код + готовый бинарник соответствующего релиза
 4. Скомпилирует и загрузит модуль ядра `facer` (эта часть всегда компилируется локально — модули ядра нельзя распространять в готовом виде между разными версиями ядра)
@@ -295,6 +295,14 @@ sudo dnf install gtk4-devel libadwaita-devel pkg-config gcc make \
 
 ```console
 sudo pacman -S gtk4 libadwaita pkgconf gcc make dkms curl tar linux-headers
+```
+</details>
+
+<details>
+<summary><b>openSUSE</b></summary>
+
+```console
+sudo zypper in gtk4-devel libadwaita-devel pkgconf-pkg-config gcc make dkms curl tar sudo
 ```
 </details>
 

--- a/README-tr.md
+++ b/README-tr.md
@@ -253,7 +253,7 @@ sudo ./predator-sense-installer
 
 **1. seçeneği** (Tam Kurulum) seçin. Yükleyici otomatik olarak:
 
-1. Dağıtımınızı algılar (Debian/Ubuntu/Mint, Fedora, Arch)
+1. Dağıtımınızı algılar (Debian/Ubuntu/Mint, Fedora, Arch, openSUSE)
 2. Sistem bağımlılıklarını kurar (GTK4, libadwaita, derleme araçları, çekirdek başlıkları)
 3. Eşleşen release'in kaynağını + hazır release binary'sini indirir
 4. `facer` çekirdek modülünü derler ve yükler (bu kısım her zaman yerel olarak derlenir — çekirdek modülleri farklı çekirdek sürümleri arasında hazır olarak dağıtılamaz)
@@ -295,6 +295,14 @@ sudo dnf install gtk4-devel libadwaita-devel pkg-config gcc make \
 
 ```console
 sudo pacman -S gtk4 libadwaita pkgconf gcc make dkms curl tar linux-headers
+```
+</details>
+
+<details>
+<summary><b>openSUSE</b></summary>
+
+```console
+sudo zypper in gtk4-devel libadwaita-devel pkgconf-pkg-config gcc make dkms curl tar sudo
 ```
 </details>
 

--- a/README-zh.md
+++ b/README-zh.md
@@ -253,7 +253,7 @@ sudo ./predator-sense-installer
 
 选择**选项 1**（完整安装）。安装程序会自动：
 
-1. 检测你的发行版（Debian/Ubuntu/Mint、Fedora、Arch）
+1. 检测你的发行版（Debian/Ubuntu/Mint、Fedora、Arch、openSUSE）
 2. 安装系统依赖（GTK4、libadwaita、构建工具、内核头文件）
 3. 下载对应 release 的源码 + 预编译二进制文件
 4. 编译并加载 `facer` 内核模块（这部分始终在本地编译，因为内核模块无法跨不同内核版本预编译分发）
@@ -295,6 +295,14 @@ sudo dnf install gtk4-devel libadwaita-devel pkg-config gcc make \
 
 ```console
 sudo pacman -S gtk4 libadwaita pkgconf gcc make dkms curl tar linux-headers
+```
+</details>
+
+<details>
+<summary><b>openSUSE</b></summary>
+
+```console
+sudo zypper in gtk4-devel libadwaita-devel pkgconf-pkg-config gcc make dkms curl tar sudo
 ```
 </details>
 

--- a/README.md
+++ b/README.md
@@ -253,7 +253,7 @@ sudo ./predator-sense-installer
 
 Select **option 1** (Full Installation). The installer will automatically:
 
-1. Detect your distribution (Debian/Ubuntu/Mint, Fedora, Arch)
+1. Detect your distribution (Debian/Ubuntu/Mint, Fedora, Arch, openSUSE)
 2. Install system dependencies (GTK4, libadwaita, build tools, kernel headers)
 3. Download the matching release's source + prebuilt binary
 4. Compile and load the `facer` kernel module (this part always compiles locally — kernel modules can't be shipped prebuilt across different kernel versions)
@@ -295,6 +295,14 @@ sudo dnf install gtk4-devel libadwaita-devel pkg-config gcc make \
 
 ```console
 sudo pacman -S gtk4 libadwaita pkgconf gcc make dkms curl tar linux-headers
+```
+</details>
+
+<details>
+<summary><b>openSUSE</b></summary>
+
+```console
+sudo zypper in gtk4-devel libadwaita-devel pkgconf-pkg-config gcc make dkms curl tar sudo
 ```
 </details>
 

--- a/predator-sense-gui/installer/src/install.rs
+++ b/predator-sense-gui/installer/src/install.rs
@@ -799,7 +799,7 @@ impl Installer {
                     "install",
                     "gtk4-devel",
                     "libadwaita-devel",
-                    "pkg-config",
+                    "pkgconf-pkg-config",
                     "gcc",
                     "make",
                     "dkms",


### PR DESCRIPTION
## Summary

Completes openSUSE Tumbleweed(zypper) support added in #52 by documenting it in all READMEs and fixing a package name in the `install.rs`.

## Changes

### Documentation
- Updated distribution detection text in all READMEs to include `openSUSE`
- Added openSUSE prerequisites section (`<details>`) with the zypper install command for all READMEs

### Code Fix
- Changed `pkg-config`  to  `pkgconf-pkg-config` in `install.rs` (the actual zypper package name on openSUSE)

### Testing
v0.3.0 works fine on my main environment (further testing on the way). There are some issues on v0.2.84-preview when adjusting the keyboard light using fn + F10, the brightness of the screen will change to 0%. Can be resolved by log out and log in.


```console
linux@localhost:~/Desktop/predator-sense/predator-sense-gui/installer/target/release> sudo zypper in gtk4-devel libadwaita-devel pkg-config gcc make dkms curl tar sudo
Loading repository data...
Reading installed packages...
'curl' is already installed.
No update candidate for 'curl-8.21.0-1.2.x86_64'. The highest available version is already installed.
'tar' is already installed.
No update candidate for 'tar-1.35-10.1.x86_64'. The highest available version is already installed.
'make' is already installed.
No update candidate for 'make-4.4.1-3.7.x86_64'. The highest available version is already installed.
'sudo' is already installed.
No update candidate for 'sudo-1.9.17p2-3.3.x86_64'. The highest available version is already installed.
'pkg-config' not found in package names. Trying capabilities.
'pkgconf-pkg-config' providing 'pkg-config' is already installed.
Resolving package dependencies...
```